### PR TITLE
travis: disable tflint for now

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.terraform

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,4 +13,7 @@ script:
   - docker run --rm -v $(pwd):/data --workdir=/data -t hashicorp/terraform:0.10.7 validate -check-variables=false
   - docker run --rm -v $(pwd):/data --workdir=/data -t hashicorp/terraform:0.10.7 fmt -write=false -diff=true -check=true
   - docker run --rm -v $(pwd):/data --workdir=/data -t hashicorp/terraform:0.10.7 get
-  - docker run --rm -v $(pwd):/data --workdir=/data -t wata727/tflint:0.5.1 --error-with-issues
+    # tflint chokes when trying to check our syntax because of this issue: https://github.com/wata727/tflint/issues/204
+    # specifically, it's currently unable to parse the construct we have at https://github.com/blinkist/terraform-aws-airship-ecs-service/blob/85dc02a8b0a1def86186d46167ace55d7375f13b/main.tf#L204
+    # fixing it is pretty involved and the author plans to rip out the parsing in favour of terraform's anyway. so for now, just disable it.
+#  - docker run --rm -v $(pwd):/data --workdir=/data -t wata727/tflint:0.5.1 --error-with-issues


### PR DESCRIPTION
It doesn't work properly against our module because of an upstream bug, and
the author plans to rewrite that code significantly; so just disable it
until it's properly fixed upstream.