### PR TITLE
&& length(var.custom_listen_hosts) > 0 is redundant

### DIFF
--- a/modules/alb_handling/main.tf
+++ b/modules/alb_handling/main.tf
@@ -90,7 +90,7 @@ data "template_file" "custom_listen_host" {
 ##
 ## An aws_lb_listener_rule will only be created when a service has a load balancer attached
 resource "aws_lb_listener_rule" "host_based_routing_custom_listen_host" {
-  count = "${local.create && length(var.custom_listen_hosts) > 0 ? length(var.custom_listen_hosts) : 0 }"
+  count = "${local.create ? length(var.custom_listen_hosts) : 0 }"
 
   listener_arn = "${var.lb_listener_arn}"
 
@@ -108,7 +108,7 @@ resource "aws_lb_listener_rule" "host_based_routing_custom_listen_host" {
 ##
 ## An aws_lb_listener_rule will only be created when a service has a load balancer attached
 resource "aws_lb_listener_rule" "host_based_routing_ssl_custom_listen_host" {
-  count = "${local.create && length(var.custom_listen_hosts) > 0 ? length(var.custom_listen_hosts) : 0 }"
+  count = "${local.create ? length(var.custom_listen_hosts) : 0 }"
 
   listener_arn = "${var.lb_listener_arn_https}"
 


### PR DESCRIPTION
Removing unnecessary conditional logic.