### PR TITLE
Changes to alb handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ The Role ARN of the ECS Service is exported, and can be used to add other permis
 
 module "demo_web" {
   source  = "blinkist/airship-ecs-service/aws"
-  version = "0.4.1"
+  version = "0.6.0"
 
   name   = "demo-web"
 
@@ -120,7 +120,7 @@ module "demo_web" {
   # load_balancing_enabled sets if a load balancer will be attached to the ecs service / target group
   load_balancing_enabled = true
   load_balancing_properties {
-    # The default route53 record type, currently CNAME to be backwards compatible
+    # The default route53 record type, can be CNAME, ALIAS or NONE, currently CNAME to be backwards compatible
     # route53_record_type = "CNAME"
 
     # Unique identifier for the weighted IN A Alias Record 
@@ -139,9 +139,6 @@ module "demo_web" {
 
     # The route53 zone for which we create a subdomain
     route53_zone_id       = "${aws_route53_zone.shared_ext_services_domain.zone_id}"
-
-    # Do we actually want to create the subdomain, default to true
-    # create_route53_record = true
 
     # After which threshold in health check is the task marked as unhealthy, defaults to 3
     # unhealthy_threshold   = "3"
@@ -226,7 +223,7 @@ module "demo_web" {
 
 module "demo_web" {
   source  = "blinkist/airship-ecs-service/aws"
-  version = "0.4.1"
+  version = "0.6.0"
 
   name   = "demo-worker"
 
@@ -274,7 +271,7 @@ module "demo_web" {
 
 module "demo_web" {
   source  = "blinkist/airship-ecs-service/aws"
-  version = "0.4.1"
+  version = "0.6.0"
 
   name   = "demo5-web"
 
@@ -288,7 +285,7 @@ module "demo_web" {
     # The default route53 record type, currently CNAME to be backwards compatible
     # route53_record_type = "CNAME"
     # Unique identifier for the weighted IN A Alias Record 
-    # route53_a_record_identifier = "identifier"
+    # route53_record_identifier = "identifier"
     lb_arn                = "${module.alb_shared_services_ext.load_balancer_id}"
     lb_listener_arn_https = "${element(module.alb_shared_services_ext.https_listener_arns,0)}"
     lb_listener_arn       = "${element(module.alb_shared_services_ext.http_tcp_listener_arns,0)}"

--- a/README.md
+++ b/README.md
@@ -117,9 +117,14 @@ module "demo_web" {
   awsvpc_subnets            = ["${module.vpc.private_subnets}"]
   awsvpc_security_group_ids = ["${module.demo_sg.this_security_group_id}"]
 
-  # load_balancing_properties takes care of binding the service to an ( Application Load Balancer) ALB
-  # when left-out the service, will not be attached to a load-balancer 
+  # load_balancing_enabled sets if a load balancer will be attached to the ecs service / target group
+  load_balancing_enabled = true
   load_balancing_properties {
+    # The default route53 record type, currently CNAME to be backwards compatible
+    # route53_record_type = "CNAME"
+
+    # Unique identifier for the weighted IN A Alias Record 
+    # route53_a_record_identifier = "identifier"
 
     # The ARN of the ALB, when left-out the service, will not be attached to a load-balance
     lb_arn                = "${module.alb_shared_services_ext.load_balancer_id}"
@@ -277,7 +282,13 @@ module "demo_web" {
 
   # scheduling_strategy = "REPLICA""""
 
+  # use_alb needs to be set to true
+  load_balancing_enabled = true
   load_balancing_properties {
+    # The default route53 record type, currently CNAME to be backwards compatible
+    # route53_record_type = "CNAME"
+    # Unique identifier for the weighted IN A Alias Record 
+    # route53_a_record_identifier = "identifier"
     lb_arn                = "${module.alb_shared_services_ext.load_balancer_id}"
     lb_listener_arn_https = "${element(module.alb_shared_services_ext.https_listener_arns,0)}"
     lb_listener_arn       = "${element(module.alb_shared_services_ext.http_tcp_listener_arns,0)}"

--- a/main.tf
+++ b/main.tf
@@ -30,9 +30,6 @@ module "iam" {
   # kms_keys define which KMS keys this ecs_service can access.
   kms_keys = "${var.kms_keys}"
 
-  # kms_keys define which KMS keys this ecs_service can access.
-  kms_keys = "${var.kms_keys}"
-
   # ssm_paths define which SSM paths the ecs_service can access
   ssm_paths = "${var.ssm_paths}"
 
@@ -79,10 +76,8 @@ module "alb_handling" {
   # Sets the deregistration_delay for the targetgroup
   deregistration_delay = "${lookup(var.load_balancing_properties,"deregistration_delay", var.default_load_balancing_properties_deregistration_delay)}"
 
-  # create_route53_record sets if this module creates a Route53 record.
-  create_route53_record = "${lookup(var.load_balancing_properties,"create_route53_record", var.default_load_balancing_properties_create_route53_record)}"
-
-  # route53_record_type sets the record type of the route53 record, defaults to cname
+  # route53_record_type sets the record type of the route53 record, can be ALIAS, CNAME or NONE,  defaults to CNAME
+  # In case of NONE no record will be made
   route53_record_type = "${lookup(var.load_balancing_properties,"route53_record_type", var.default_load_balancing_properties_route53_record_type)}"
 
   # Sets the zone in which the sub-domain will be added for this service
@@ -91,8 +86,8 @@ module "alb_handling" {
   # Sets name for the sub-domain, we default to *name
   route53_name = "${var.name}"
 
-  # route53_a_record_identifier sets the identifier of the weighted IN A Alias record
-  route53_a_record_identifier = "${lookup(var.load_balancing_properties,"route53_a_record_identifier", var.default_load_balancing_properties_route53_a_record_identifier)}"
+  # route53_a_record_identifier sets the identifier of the weighted Alias A record
+  route53_record_identifier = "${lookup(var.load_balancing_properties,"route53_record_identifier", var.default_load_balancing_properties_route53_record_identifier)}"
 
   # the custom_listen_hosts will be added as a host route rule as aws_lb_listener_rule to the given service e.g. www.domain.com -> Service
   custom_listen_hosts = "${var.custom_listen_hosts}"

--- a/main.tf
+++ b/main.tf
@@ -30,6 +30,9 @@ module "iam" {
   # kms_keys define which KMS keys this ecs_service can access.
   kms_keys = "${var.kms_keys}"
 
+  # kms_keys define which KMS keys this ecs_service can access.
+  kms_keys = "${var.kms_keys}"
+
   # ssm_paths define which SSM paths the ecs_service can access
   ssm_paths = "${var.ssm_paths}"
 
@@ -53,7 +56,7 @@ module "alb_handling" {
   cluster_name = "${local.cluster_name}"
 
   # Create defines if we need to create resources inside this module
-  create = "${var.create}"
+  create = "${var.create && var.load_balancing_enabled}"
 
   # lb_vpc_id sets the VPC ID of where the LB resides
   lb_vpc_id = "${lookup(var.load_balancing_properties,"lb_vpc_id", "")}"
@@ -76,14 +79,20 @@ module "alb_handling" {
   # Sets the deregistration_delay for the targetgroup
   deregistration_delay = "${lookup(var.load_balancing_properties,"deregistration_delay", var.default_load_balancing_properties_deregistration_delay)}"
 
-  # create_route53_record sets if this module creates a Route53 zone.
+  # create_route53_record sets if this module creates a Route53 record.
   create_route53_record = "${lookup(var.load_balancing_properties,"create_route53_record", var.default_load_balancing_properties_create_route53_record)}"
+
+  # route53_record_type sets the record type of the route53 record, defaults to cname
+  route53_record_type = "${lookup(var.load_balancing_properties,"route53_record_type", var.default_load_balancing_properties_route53_record_type)}"
 
   # Sets the zone in which the sub-domain will be added for this service
   route53_zone_id = "${lookup(var.load_balancing_properties,"route53_zone_id", "")}"
 
   # Sets name for the sub-domain, we default to *name
   route53_name = "${var.name}"
+
+  # route53_a_record_identifier sets the identifier of the weighted IN A Alias record
+  route53_a_record_identifier = "${lookup(var.load_balancing_properties,"route53_a_record_identifier", var.default_load_balancing_properties_route53_a_record_identifier)}"
 
   # the custom_listen_hosts will be added as a host route rule as aws_lb_listener_rule to the given service e.g. www.domain.com -> Service
   custom_listen_hosts = "${var.custom_listen_hosts}"

--- a/modules/alb_handling/variables.tf
+++ b/modules/alb_handling/variables.tf
@@ -69,6 +69,17 @@ variable "create_route53_record" {
   default = true
 }
 
+# Small Lookup map to validate route53_record_type
+variable "allowed_record_types" {
+  default = {
+    CNAME = "CNAME"
+    A     = "A"
+  }
+}
+
+# route53_record_type, one of the allowed values of the map allowed_record_types
+variable "route53_record_type" {}
+
 # the custom_listen_hosts will be added as a host route rule as aws_lb_listener_rule to the given service e.g. www.domain.com -> Service
 variable "custom_listen_hosts" {
   type    = "list"
@@ -79,3 +90,6 @@ variable "custom_listen_hosts" {
 variable "https_enabled" {
   default = true
 }
+
+# namespace, sets the namespace, currently used for the weighted IN A Alias record which needs an identifier
+variable "route53_a_record_identifier" {}

--- a/modules/alb_handling/variables.tf
+++ b/modules/alb_handling/variables.tf
@@ -64,16 +64,12 @@ variable "route53_name" {
   default = ""
 }
 
-# Do we want to create a record in the given route53 zone
-variable "create_route53_record" {
-  default = true
-}
-
 # Small Lookup map to validate route53_record_type
 variable "allowed_record_types" {
   default = {
+    ALIAS = "ALIAS"
     CNAME = "CNAME"
-    A     = "A"
+    NONE  = "NONE"
   }
 }
 
@@ -91,5 +87,5 @@ variable "https_enabled" {
   default = true
 }
 
-# namespace, sets the namespace, currently used for the weighted IN A Alias record which needs an identifier
-variable "route53_a_record_identifier" {}
+# route53_record_identifier, sets the identifier for the route53 record in case the record type is ALIAS 
+variable "route53_record_identifier" {}

--- a/variables.tf
+++ b/variables.tf
@@ -80,16 +80,12 @@ variable "default_load_balancing_properties_https_enabled" {
   default = true
 }
 
-variable "default_load_balancing_properties_route53_a_record_identifier" {
+variable "default_load_balancing_properties_route53_record_identifier" {
   default = "identifier"
 }
 
-variable "default_load_balancing_properties_create_route53_record" {
-  default = true
-}
-
-# By default we create a CNAME to the ALB, the moment terraform can handle CNAME to IN A ALIAS record changes
-# Route53 IN A Alias will be the default.
+# By default we create a CNAME to the ALB, the moment terraform can handle CNAME to ALIAS A record changes
+# Route53 Alias A will be the default.
 # https://github.com/terraform-providers/terraform-provider-aws/issues/5280
 variable "default_load_balancing_properties_route53_record_type" {
   default = "CNAME"

--- a/variables.tf
+++ b/variables.tf
@@ -34,6 +34,11 @@ variable "custom_listen_hosts" {
   type    = "list"
 }
 
+# load_balancing_enabled defines if we are using a load balancer for our ecs service
+variable "load_balancing_enabled" {
+  default = false
+}
+
 ## load_balancing_properties map defines the map for services hooked to a load balancer
 variable "load_balancing_properties" {
   type = "map"
@@ -75,8 +80,19 @@ variable "default_load_balancing_properties_https_enabled" {
   default = true
 }
 
+variable "default_load_balancing_properties_route53_a_record_identifier" {
+  default = "identifier"
+}
+
 variable "default_load_balancing_properties_create_route53_record" {
   default = true
+}
+
+# By default we create a CNAME to the ALB, the moment terraform can handle CNAME to IN A ALIAS record changes
+# Route53 IN A Alias will be the default.
+# https://github.com/terraform-providers/terraform-provider-aws/issues/5280
+variable "default_load_balancing_properties_route53_record_type" {
+  default = "CNAME"
 }
 
 ## capacity_properties map defines the capacity properties of the service


### PR DESCRIPTION
## What

Adding use_alb parameter when alb handling is used
Adding create_cname parameter for cname creation instead of IN A alias

## Why

We previously used length(var.lb_arn) to build local create boolean in the alb_handling submodule, this does not work in all Terraform environments as the lb_arn length cannot alwasy be computed. 

We currently have used cnames to create a record pointing to the load balancer. CNAME's can only have one occurrence of the same name. Using weighted IN A Alias multiple services can exist net to each other, also helping migrations.