### PR TITLE
evaluate_target_health does not work properly in a multi-target-group…

### DIFF
--- a/modules/alb_handling/main.tf
+++ b/modules/alb_handling/main.tf
@@ -28,7 +28,7 @@ resource "aws_route53_record" "record_alias_a" {
   alias {
     name                   = "${data.aws_lb.main.dns_name}"
     zone_id                = "${data.aws_lb.main.zone_id}"
-    evaluate_target_health = true
+    evaluate_target_health = false
   }
 
   # When all records in a group have weight set to 0, traffic is routed to all resources with equal probability


### PR DESCRIPTION
When an ALB has multiple target groups of which one is failing, the whole ALB is be marked as unhealthy to route53. ie. in a scenario with multiple weighted A records, no traffic will be sent to the microservice when one other microservice is unhealthy. Having `evaluate_target_health` set to false mitigates that.