### PR TITLE
Add volumes and mountpoints to tasks

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -144,6 +144,15 @@ module "ecs_task_definition" {
 
   # region, needed for Logging.. 
   region = "${local.region}"
+
+  # list of docker volumes to add to the task
+  docker_volumes = "${var.docker_volumes}"
+
+  # list of host paths to add as volumes to the task
+  host_path_volumes = "${var.host_path_volumes}"
+
+  # list of mount points to add to all containers in the task
+  mountpoints = "${var.mountpoints}"
 }
 
 #

--- a/main.tf
+++ b/main.tf
@@ -145,8 +145,8 @@ module "ecs_task_definition" {
   # region, needed for Logging.. 
   region = "${local.region}"
 
-  # list of docker volumes to add to the task
-  docker_volumes = "${var.docker_volumes}"
+  # a Docker volume to add to the task
+  docker_volume = "${var.docker_volume}"
 
   # list of host paths to add as volumes to the task
   host_path_volumes = "${var.host_path_volumes}"

--- a/main.tf
+++ b/main.tf
@@ -27,8 +27,16 @@ module "iam" {
   # Region is used multiple times inside this module, we pass this through so that we don't need multiple datasources
   region = "${local.region}"
 
+  # kms_enabled sets whether this ecs_service should be able to access the given KMS keys.
+  # Defaults to true; if no kms_paths are given, set this to false.
+  kms_enabled = "${var.kms_enabled}"
+
   # kms_keys define which KMS keys this ecs_service can access.
   kms_keys = "${var.kms_keys}"
+
+  # ssm_enabled sets whether this ecs_service should be able to access the given SSM paths.
+  # Defaults to true; if no ssm_paths are given, set this to false.
+  ssm_enabled = "${var.ssm_enabled}"
 
   # ssm_paths define which SSM paths the ecs_service can access
   ssm_paths = "${var.ssm_paths}"

--- a/modules/ecs_task_definition/container-definition.json
+++ b/modules/ecs_task_definition/container-definition.json
@@ -7,6 +7,7 @@
     "name": "${container_name}",
     ${hostname_block}
     ${portmappings_block}
+    ${mountpoints_block}
     "environment": ${envvars},
     "logConfiguration": {
         "logDriver": "awslogs",

--- a/modules/ecs_task_definition/main.tf
+++ b/modules/ecs_task_definition/main.tf
@@ -15,6 +15,36 @@ data "template_file" "portmapping" {
 EOF
 }
 
+data "template_file" "mountpoint" {
+  count = "${length(var.mountpoints)}"
+
+  vars {
+    source_volume  = "${lookup(var.mountpoints[count.index], "source_volume")}"
+    container_path = "${lookup(var.mountpoints[count.index], "container_path")}"
+    read_only      = "${lookup(var.mountpoints[count.index], "read_only", "false")}"
+  }
+
+  template = <<EOF
+{
+	"sourceVolume": "$${source_volume}",
+	"containerPath": "$${container_path}",
+	"readOnly": $${read_only}
+}
+EOF
+}
+
+data "template_file" "mountpoints" {
+  vars {
+    values = "${join(",", data.template_file.mountpoint.*.rendered)}"
+  }
+
+  template = <<EOF
+"mountPoints": [
+    $${values}
+    ],
+EOF
+}
+
 locals {
   # container0_name is the name of the first container
   container0_name = "${lookup(var.container_properties[0], "name")}"
@@ -40,11 +70,11 @@ resource "null_resource" "envvars_as_list_of_maps" {
   )}"
 }
 
-data "template_file" "task_definition" {
-  # We have as much task definitions per container as given maps inside the container properties variable
+data "template_file" "container_definition" {
+  # We have as many container definitions per task as given maps inside the container properties variable
   count = "${var.create && length(var.container_properties) > 0 ? 1 : 0}"
 
-  template = "${file("${"${path.module}/task-definition.json"}")}"
+  template = "${file("${"${path.module}/container-definition.json"}")}"
 
   vars {
     image_url = "${lookup(var.container_properties[count.index], "image_url")}"
@@ -63,7 +93,8 @@ data "template_file" "task_definition" {
     container_name = "${lookup(var.container_properties[count.index], "name")}"
 
     # In non-awsvpc environments we can set the hostname
-    hostname_block = "${var.awsvpc_enabled == 0 ? "\"hostname\":\"${var.name}-${count.index}\",\n" :""}"
+    hostname_block    = "${var.awsvpc_enabled == 0 ? "\"hostname\":\"${var.name}-${count.index}\",\n" :""}"
+    mountpoints_block = "${data.template_file.mountpoints.rendered}"
 
     # Cloudwatch logging
     log_group_region = "${var.region}"
@@ -84,7 +115,12 @@ resource "aws_ecs_task_definition" "app" {
   cpu    = "${var.fargate_enabled  ? lookup(var.container_properties[0], "cpu"): "" }"
   memory = "${var.fargate_enabled  ? lookup(var.container_properties[0], "mem"): "" }"
 
-  container_definitions = "[${join(",",data.template_file.task_definition.*.rendered)}]"
+  # This is a hack: https://github.com/hashicorp/terraform/issues/14037#issuecomment-361202716
+  # This WILL break in Terraform 0.12: https://github.com/hashicorp/terraform/issues/14037#issuecomment-361358928
+  # but we need something that works before then
+  volume = "${concat(var.docker_volumes, var.host_path_volumes)}"
+
+  container_definitions = "[${join(",",data.template_file.container_definition.*.rendered)}]"
   network_mode          = "${var.awsvpc_enabled ? "awsvpc" : "bridge"}"
 
   # We need to ignore future container_definitions, and placement_constraints, as other tools take care of updating the task definition

--- a/modules/ecs_task_definition/main.tf
+++ b/modules/ecs_task_definition/main.tf
@@ -126,12 +126,12 @@ resource "aws_ecs_task_definition" "app" {
   # include a nested map; therefore the only way to currently sanely support
   # Docker volume blocks is to only consider the single volume case.
   volume = {
-    name = "${lookup(var.docker_volume, "name") != "" ? lookup(var.docker_volume, "name") : ""}"
+    name = "${lookup(var.docker_volume, "name", "")}"
 
     docker_volume_configuration {
-      autoprovision = "${lookup(var.docker_volume, "autoprovision") != "" ? lookup(var.docker_volume, "autoprovision") : ""}"
-      scope         = "${lookup(var.docker_volume, "scope") != "" ? lookup(var.docker_volume, "scope") : ""}"
-      driver        = "${lookup(var.docker_volume, "driver") != "" ? lookup(var.docker_volume, "driver") : ""}"
+      autoprovision = "${lookup(var.docker_volume, "autoprovision", "")}"
+      scope         = "${lookup(var.docker_volume, "scope", "")}"
+      driver        = "${lookup(var.docker_volume, "driver", "")}"
     }
   }
 

--- a/modules/ecs_task_definition/output.tf
+++ b/modules/ecs_task_definition/output.tf
@@ -10,5 +10,5 @@ output "container0_port" {
 
 # The arn of the task definition
 output "aws_ecs_task_definition_arn" {
-  value = "${element(concat(aws_ecs_task_definition.app.*.arn, list("")), 0)}"
+  value = "${element(concat(aws_ecs_task_definition.app.*.arn, aws_ecs_task_definition.app_with_docker_volume.*.arn), 0)}"
 }

--- a/modules/ecs_task_definition/variables.tf
+++ b/modules/ecs_task_definition/variables.tf
@@ -45,3 +45,44 @@ variable "region" {}
 
 # launch_type sets the launch_type, either EC2 or FARGATE
 variable "launch_type" {}
+
+# list of docker volumes to add to the task
+variable "docker_volumes" {
+  type    = "list"
+  default = []
+
+  # {
+  #    name = "bla",
+  #    scope == "shared",
+  #    autoprovision = true,
+  #    driver = "foo"
+  # }
+  #
+  /* NOT supported, as these are maps
+     driver_opts = N/A
+     labels = N/A
+  */
+}
+
+# list of host paths to add to the task
+variable "host_path_volumes" {
+  type    = "list"
+  default = []
+
+  # {
+  #   name = "service-storage",
+  #   host_path = "/foo"
+  # },
+}
+
+# list of mount points to add to every container in the task
+variable "mountpoints" {
+  type    = "list"
+  default = []
+
+  # {
+  #   source_volume = "service-storage"
+  #   container_path = "/foo"
+  #   read_only = "false"
+  # },
+}

--- a/modules/ecs_task_definition/variables.tf
+++ b/modules/ecs_task_definition/variables.tf
@@ -46,32 +46,32 @@ variable "region" {}
 # launch_type sets the launch_type, either EC2 or FARGATE
 variable "launch_type" {}
 
-# list of docker volumes to add to the task
-variable "docker_volumes" {
-  type    = "list"
-  default = []
+# A Docker volume to add to the task
+variable "docker_volume" {
+  type    = "map"
+  default = {}
 
   # {
-  #    name = "bla",
-  #    scope == "shared",
-  #    autoprovision = true,
-  #    driver = "foo"
+  # # these properties are supported as a 'flattened' version of the docker volume configuration:
+  # # https://www.terraform.io/docs/providers/aws/r/ecs_task_definition.html#docker_volume_configuration
+  #     name = "bla",
+  #     scope == "shared",
+  #     autoprovision = true,
+  #     driver = "foo"
+  # # these properties are NOT supported, as they are nested maps in the resource's configuration
+  # #   driver_opts = NA
+  # #   labels = NA
   # }
-  #
-  /* NOT supported, as these are maps
-     driver_opts = N/A
-     labels = N/A
-  */
 }
 
-# list of host paths to add to the task
+# list of host paths to add as volumes to the task
 variable "host_path_volumes" {
   type    = "list"
   default = []
 
   # {
-  #   name = "service-storage",
-  #   host_path = "/foo"
+  #     name = "service-storage",
+  #     host_path = "/foo"
   # },
 }
 
@@ -81,8 +81,8 @@ variable "mountpoints" {
   default = []
 
   # {
-  #   source_volume = "service-storage"
-  #   container_path = "/foo"
-  #   read_only = "false"
+  #     source_volume = "service-storage",
+  #     container_path = "/foo",
+  #     read_only = "false"
   # },
 }

--- a/modules/iam/main.tf
+++ b/modules/iam/main.tf
@@ -52,7 +52,7 @@ data "aws_iam_policy_document" "kms_permissions" {
 
 # Allow KMS-Decrypt permissions for the ECS Task Role
 resource "aws_iam_role_policy" "kms_permissions" {
-  count  = "${var.create ? 1 : 0 }"
+  count  = "${var.create && length(var.kms_keys) > 0 ? 1 : 0 }"
   name   = "kms-permissions"
   role   = "${aws_iam_role.ecs_tasks_role.id}"
   policy = "${data.aws_iam_policy_document.kms_permissions.json}"
@@ -71,7 +71,7 @@ data "aws_iam_policy_document" "ssm_permissions" {
 
 # Add the SSM policy to the task role
 resource "aws_iam_role_policy" "ssm_permissions" {
-  count  = "${var.create ? 1 : 0 }"
+  count  = "${var.create && length(var.ssm_paths) > 0 ? 1 : 0 }"
   name   = "ssm-permissions"
   role   = "${aws_iam_role.ecs_tasks_role.id}"
   policy = "${data.aws_iam_policy_document.ssm_permissions.json}"

--- a/modules/iam/main.tf
+++ b/modules/iam/main.tf
@@ -52,7 +52,7 @@ data "aws_iam_policy_document" "kms_permissions" {
 
 # Allow KMS-Decrypt permissions for the ECS Task Role
 resource "aws_iam_role_policy" "kms_permissions" {
-  count  = "${var.create && length(var.kms_keys) > 0 ? 1 : 0 }"
+  count  = "${(var.create && var.kms_enabled) ? 1 : 0 }"
   name   = "kms-permissions"
   role   = "${aws_iam_role.ecs_tasks_role.id}"
   policy = "${data.aws_iam_policy_document.kms_permissions.json}"
@@ -71,7 +71,7 @@ data "aws_iam_policy_document" "ssm_permissions" {
 
 # Add the SSM policy to the task role
 resource "aws_iam_role_policy" "ssm_permissions" {
-  count  = "${var.create && length(var.ssm_paths) > 0 ? 1 : 0 }"
+  count  = "${(var.create && var.ssm_enabled) ? 1 : 0 }"
   name   = "ssm-permissions"
   role   = "${aws_iam_role.ecs_tasks_role.id}"
   policy = "${data.aws_iam_policy_document.ssm_permissions.json}"

--- a/modules/iam/variables.tf
+++ b/modules/iam/variables.tf
@@ -14,9 +14,21 @@ variable "fargate_enabled" {
   default = false
 }
 
+# Whether to provide access to the supplied kms_keys. If no kms keys are
+# passed, set this to false.
+variable "kms_enabled" {
+  default = true
+}
+
 # List of KMS keys the task has access to
 variable "kms_keys" {
   default = []
+}
+
+# Whether to provide access to the supplied ssm_paths. If no ssm paths are
+# passed, set this to false.
+variable "ssm_enabled" {
+  default = true
 }
 
 # List of SSM Paths the task has access to

--- a/variables.tf
+++ b/variables.tf
@@ -271,9 +271,21 @@ variable "name" {
   description = "The name of the project, must be unique ."
 }
 
+# Whether to provide access to the supplied kms_keys. If no kms keys are
+# passed, set this to false.
+variable "kms_enabled" {
+  default = true
+}
+
 # List of KMS keys the task has access to
 variable "kms_keys" {
   default = []
+}
+
+# Whether to provide access to the supplied ssm_paths. If no ssm paths are
+# passed, set this to false.
+variable "ssm_enabled" {
+  default = true
 }
 
 # List of SSM Paths the task has access to

--- a/variables.tf
+++ b/variables.tf
@@ -301,42 +301,43 @@ variable "s3_rw_paths" {
   default = []
 }
 
-# list of docker volumes to add to the task
-variable "docker_volumes" {
-  type    = "list"
-  default = []
+# A Docker volume to add to the task
+variable "docker_volume" {
+  type    = "map"
+  default = {}
 
   # {
-  #    name = "bla",
-  #    scope == "shared",
-  #    autoprovision = true,
-  #    driver = "foo"
+  # # these properties are supported as a 'flattened' version of the docker volume configuration:
+  # # https://www.terraform.io/docs/providers/aws/r/ecs_task_definition.html#docker_volume_configuration
+  #     name = "bla",
+  #     scope == "shared",
+  #     autoprovision = true,
+  #     driver = "foo"
+  # # these properties are NOT supported, as they are nested maps in the resource's configuration
+  # #   driver_opts = NA
+  # #   labels = NA
   # }
-  #
-  /* NOT supported, as these are aps
-     driver_opts = NA
-     labels = NA
-  */
 }
 
-# list of host paths to add to the task
+# list of host paths to add as volumes to the task
 variable "host_path_volumes" {
   type    = "list"
   default = []
 
   # {
-  #   name = "service-storage",
-  #   host_path = "/foo"
+  #     name = "service-storage",
+  #     host_path = "/foo"
   # },
 }
 
+# list of mount points to add to every container in the task
 variable "mountpoints" {
   type    = "list"
   default = []
 
   # {
-  #   source_volume = "service-storage"
-  #   container_path = "/foo"
-  #   read_only = "false"
+  #     source_volume = "service-storage",
+  #     container_path = "/foo",
+  #     read_only = "false"
   # },
 }

--- a/variables.tf
+++ b/variables.tf
@@ -180,7 +180,7 @@ variable "default_capacity_properties_deployment_minimum_healthy_percent" {
 #     # name defines the name of the container, this is used for the AWS Logstream, and the targetgroup registration
 #     name       = "nginx"
 #   
-#     # The port of the application
+#     # port of the application (optional)
 #     port       = "80"
 #
 #     # mem_reservation defines the soft limit for the container, defaults to null
@@ -299,4 +299,44 @@ variable "s3_ro_paths" {
 # S3 Read-write paths the Task has access to
 variable "s3_rw_paths" {
   default = []
+}
+
+# list of docker volumes to add to the task
+variable "docker_volumes" {
+  type    = "list"
+  default = []
+
+  # {
+  #    name = "bla",
+  #    scope == "shared",
+  #    autoprovision = true,
+  #    driver = "foo"
+  # }
+  #
+  /* NOT supported, as these are aps
+     driver_opts = NA
+     labels = NA
+  */
+}
+
+# list of host paths to add to the task
+variable "host_path_volumes" {
+  type    = "list"
+  default = []
+
+  # {
+  #   name = "service-storage",
+  #   host_path = "/foo"
+  # },
+}
+
+variable "mountpoints" {
+  type    = "list"
+  default = []
+
+  # {
+  #   source_volume = "service-storage"
+  #   container_path = "/foo"
+  #   read_only = "false"
+  # },
 }


### PR DESCRIPTION
This is an attempt to add basic volume support to tasks. Unfortunately
there are a few limitations right now because of Terraform syntax:
- Not all parameters to a Docker volume configuration are supported, as
  some of them require nested maps
- Mountpoints are added to all containers in a task (i.e. they can't be
  scoped to specific containers only)

- (new) Only a single Docker volume is supported, as the definition of its configuration is a block and we can't generate multiple blocks