### PR TITLE
Cognito Authentication Addition

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# AWS ECS Service Terraform Module [![Build Status](https://travis-ci.org/blinkist/terraform-aws-airship-ecs-service.svg?branch=master)](https://travis-ci.org/blinkist/terraform-aws-airship-ecs-service)
+# AWS ECS Service Terraform Module [![Build Status](https://travis-ci.org/blinkist/terraform-aws-airship-ecs-service.svg?branch=master)](https://travis-ci.org/blinkist/terraform-aws-airship-ecs-service) [![Slack Community](https://slack.cloudposse.com/badge.svg)](https://slack.cloudposse.com)
 
 ![](https://raw.githubusercontent.com/blinkist/airship-tf-ecs-service/master/_readme_resources/airship.png)
 

--- a/README.md
+++ b/README.md
@@ -88,8 +88,10 @@ The Role ARN of the ECS Service is exported, and can be used to add other permis
 * [x] Deregistration delay parameter allows for fast deployments
 * [x] The scheduling_strategy DAEMON/REPLICA can be set 
 * [x] Adding of Volumes / Mountpoints in case Docker Volume Drivers are used.
+* [x] HTTP to HTTP Redirect functionality
+* [x] Cognito Auth for https endpoints
 * [ ] ECS Service discovery
-* [ ] Path based ALB Rules 
+* [ ] Path based ALB Rules
 * [ ] SSL SNI Adding for custom hostnames
 * [ ] Integrated IAM Permissions for *
 
@@ -147,6 +149,23 @@ module "demo_web" {
 
     # The amount time for Elastic Load Balancing to wait before changing the state of a deregistering target from draining to unused. The range is 0-3600 seconds. 
     # deregistration_delay = "300"
+
+    # Creates a listener rule which redirects to https
+    # redirect_http_to_https = false
+
+    # cognito_auth_enabled is set when cognito authentication is used for the https listener
+    # Important to have redirect_http_to_https set to true as http authentication is only added to the https listener
+
+    # cognito_auth_enabled = false
+ 
+    # cognito_user_pool_arn defines the cognito user pool arn for the added cognito authentication
+    # cognito_user_pool_arn = ""
+ 
+    # cognito_user_pool_client_id defines the cognito_user_pool_client_id
+    # cognito_user_pool_client_id = ""
+ 
+    # cognito_user_pool_domain sets the domain of the cognito_user_pool
+    # cognito_user_pool_domain = ""
   }
 
   # custom_listen_hosts defines extra listener rules to route to the ALB Targetgroup

--- a/main.tf
+++ b/main.tf
@@ -91,11 +91,26 @@ module "alb_handling" {
   # custom_listen_hosts will be added as a host route rule as aws_lb_listener_rule to the given service e.g. www.domain.com -> Service
   custom_listen_hosts = "${var.custom_listen_hosts}"
 
+  # redirect_http_to_https creates lb listeners which redirect incoming http traffic to https
+  redirect_http_to_https = "${lookup(var.load_balancing_properties,"redirect_http_to_https", var.default_load_balancing_properties_redirect_http_to_https)}"
+
   # health_uri defines which health-check uri the target group needs to check on for health_check
   health_uri = "${lookup(var.load_balancing_properties,"health_uri", var.default_load_balancing_properties_health_uri)}"
 
   # target_type is the alb_target_group target, in case of EC2 it's instance, in case of FARGATE it's IP
   target_type = "${var.awsvpc_enabled ? "ip" : "instance"}"
+
+  # cognito_auth_enabled is set when cognito authentication is used for the https listener
+  cognito_auth_enabled = "${lookup(var.load_balancing_properties,"cognito_auth_enabled", var.default_load_balancing_properties_cognito_auth_enabled)}"
+
+  # cognito_user_pool_arn defines the cognito user pool arn for the added cognito authentication
+  cognito_user_pool_arn = "${lookup(var.load_balancing_properties,"cognito_user_pool_arn", var.default_load_balancing_properties_cognito_user_pool_arn)}"
+
+  # cognito_user_pool_client_id defines the cognito_user_pool_client_id
+  cognito_user_pool_client_id = "${lookup(var.load_balancing_properties,"cognito_user_pool_client_id", var.default_load_balancing_properties_cognito_user_pool_client_id)}"
+
+  # cognito_user_pool_domain sets the domain of the cognito_user_pool
+  cognito_user_pool_domain = "${lookup(var.load_balancing_properties,"cognito_user_pool_domain", var.default_load_balancing_properties_cognito_user_pool_domain)}"
 }
 
 ###### CloudWatch Logs

--- a/modules/alb_handling/main.tf
+++ b/modules/alb_handling/main.tf
@@ -61,7 +61,7 @@ resource "aws_lb_target_group" "service" {
 ##
 ## An aws_lb_listener_rule will only be created when a service has a load balancer attached
 resource "aws_lb_listener_rule" "host_based_routing" {
-  count = "${var.create && local.route53_record_type != "NONE" ? 1 : 0 }"
+  count = "${var.create && ! var.redirect_http_to_https && local.route53_record_type != "NONE" ? 1 : 0 }"
 
   listener_arn = "${var.lb_listener_arn}"
 
@@ -82,9 +82,37 @@ resource "aws_lb_listener_rule" "host_based_routing" {
 }
 
 ##
+## aws_lb_listener_rule which redirects http to https
+resource "aws_lb_listener_rule" "host_based_routing_redirect_to_https" {
+  count = "${var.create && var.redirect_http_to_https && local.route53_record_type != "NONE" ? 1 : 0 }"
+
+  listener_arn = "${var.lb_listener_arn}"
+
+  action {
+    type = "redirect"
+
+    redirect {
+      port        = "443"
+      protocol    = "HTTPS"
+      status_code = "HTTP_301"
+    }
+  }
+
+  condition {
+    field = "host-header"
+
+    values = ["${local.route53_record_type == "CNAME" ?
+       join("",aws_route53_record.record.*.fqdn)
+       :
+       join("",aws_route53_record.record_alias_a.*.fqdn)
+       }"]
+  }
+}
+
+##
 ## An aws_lb_listener_rule will only be created when a service has a load balancer attached
 resource "aws_lb_listener_rule" "host_based_routing_ssl" {
-  count = "${var.create && local.route53_record_type != "NONE" ? 1 : 0 }"
+  count = "${var.create && ! var.cognito_auth_enabled && local.route53_record_type != "NONE" ? 1 : 0 }"
 
   listener_arn = "${var.lb_listener_arn_https}"
 
@@ -96,7 +124,40 @@ resource "aws_lb_listener_rule" "host_based_routing_ssl" {
   condition {
     field = "host-header"
 
-    values = ["${local.route53_record_type == "CNAME" ? 
+    values = ["${local.route53_record_type == "CNAME" ?
+       join("",aws_route53_record.record.*.fqdn)
+       :
+       join("",aws_route53_record.record_alias_a.*.fqdn)
+       }"]
+  }
+}
+
+##
+## An aws_lb_listener_rule will only be created when a service has a load balancer attached
+resource "aws_lb_listener_rule" "host_based_routing_ssl_cognito_auth" {
+  count = "${var.create && var.cognito_auth_enabled && local.route53_record_type != "NONE" ? 1 : 0 }"
+
+  listener_arn = "${var.lb_listener_arn_https}"
+
+  action {
+    type = "authenticate-cognito"
+
+    authenticate_cognito {
+      user_pool_arn       = "${var.cognito_user_pool_arn}"
+      user_pool_client_id = "${var.cognito_user_pool_client_id}"
+      user_pool_domain    = "${var.cognito_user_pool_domain}"
+    }
+  }
+
+  action {
+    type             = "forward"
+    target_group_arn = "${aws_lb_target_group.service.arn}"
+  }
+
+  condition {
+    field = "host-header"
+
+    values = ["${local.route53_record_type == "CNAME" ?
        join("",aws_route53_record.record.*.fqdn)
        :
        join("",aws_route53_record.record_alias_a.*.fqdn)
@@ -117,7 +178,7 @@ data "template_file" "custom_listen_host" {
 ##
 ## An aws_lb_listener_rule will only be created when a service has a load balancer attached
 resource "aws_lb_listener_rule" "host_based_routing_custom_listen_host" {
-  count = "${var.create ? length(var.custom_listen_hosts) : 0 }"
+  count = "${var.create && ! var.redirect_http_to_https ? length(var.custom_listen_hosts) : 0 }"
 
   listener_arn = "${var.lb_listener_arn}"
 
@@ -133,11 +194,62 @@ resource "aws_lb_listener_rule" "host_based_routing_custom_listen_host" {
 }
 
 ##
+## aws_lb_listener_rule which redirects http to https for the customer listen hosts
+resource "aws_lb_listener_rule" "host_based_routing_custom_listen_host_redirect_to_https" {
+  count = "${var.create && var.redirect_http_to_https ? length(var.custom_listen_hosts) : 0 }"
+
+  listener_arn = "${var.lb_listener_arn}"
+
+  action {
+    type = "redirect"
+
+    redirect {
+      port        = "443"
+      protocol    = "HTTPS"
+      status_code = "HTTP_301"
+    }
+  }
+
+  condition {
+    field  = "host-header"
+    values = ["${data.template_file.custom_listen_host.*.rendered[count.index]}"]
+  }
+}
+
+##
 ## An aws_lb_listener_rule will only be created when a service has a load balancer attached
 resource "aws_lb_listener_rule" "host_based_routing_ssl_custom_listen_host" {
-  count = "${var.create ? length(var.custom_listen_hosts) : 0 }"
+  count = "${var.create && ! var.cognito_auth_enabled ? length(var.custom_listen_hosts) : 0 }"
 
   listener_arn = "${var.lb_listener_arn_https}"
+
+  action {
+    type             = "forward"
+    target_group_arn = "${aws_lb_target_group.service.arn}"
+  }
+
+  condition {
+    field  = "host-header"
+    values = ["${data.template_file.custom_listen_host.*.rendered[count.index]}"]
+  }
+}
+
+##
+## An aws_lb_listener_rule will only be created when a service has a load balancer attached
+resource "aws_lb_listener_rule" "host_based_routing_ssl_custom_listen_host_cognito_auth" {
+  count = "${var.create && var.cognito_auth_enabled ? length(var.custom_listen_hosts) : 0 }"
+
+  listener_arn = "${var.lb_listener_arn_https}"
+
+  action {
+    type = "authenticate-cognito"
+
+    authenticate_cognito {
+      user_pool_arn       = "${var.cognito_user_pool_arn}"
+      user_pool_client_id = "${var.cognito_user_pool_client_id}"
+      user_pool_domain    = "${var.cognito_user_pool_domain}"
+    }
+  }
 
   action {
     type             = "forward"

--- a/modules/alb_handling/main.tf
+++ b/modules/alb_handling/main.tf
@@ -264,5 +264,5 @@ resource "aws_lb_listener_rule" "host_based_routing_ssl_custom_listen_host_cogni
 
 # This is an output the ecs_service depends on. This to make sure the target_group is attached to an alb before adding to a service. The actual content is useless
 output "aws_lb_listener_rules" {
-  value = ["${concat(aws_lb_listener_rule.host_based_routing.*.arn,aws_lb_listener_rule.host_based_routing_custom_listen_host.*.arn, list())}"]
+  value = ["${concat(aws_lb_listener_rule.host_based_routing.*.arn,aws_lb_listener_rule.host_based_routing_custom_listen_host.*.arn, aws_lb_listener_rule.host_based_routing.host_based_routing_ssl_custom_listen_host_cognito_auth.*.arn, list())}"]
 }

--- a/modules/alb_handling/main.tf
+++ b/modules/alb_handling/main.tf
@@ -261,8 +261,3 @@ resource "aws_lb_listener_rule" "host_based_routing_ssl_custom_listen_host_cogni
     values = ["${data.template_file.custom_listen_host.*.rendered[count.index]}"]
   }
 }
-
-# This is an output the ecs_service depends on. This to make sure the target_group is attached to an alb before adding to a service. The actual content is useless
-output "aws_lb_listener_rules" {
-  value = ["${concat(aws_lb_listener_rule.host_based_routing.*.arn,aws_lb_listener_rule.host_based_routing_custom_listen_host.*.arn, aws_lb_listener_rule.host_based_routing.host_based_routing_ssl_custom_listen_host_cognito_auth.*.arn, list())}"]
-}

--- a/modules/alb_handling/output.tf
+++ b/modules/alb_handling/output.tf
@@ -1,3 +1,8 @@
 output "lb_target_group_arn" {
   value = "${element(concat(aws_lb_target_group.service.*.arn, list("")), 0)}"
 }
+
+# This is an output the ecs_service depends on. This to make sure the target_group is attached to an alb before adding to a service. The actual content is useless
+output "aws_lb_listener_rules" {
+  value = ["${concat(aws_lb_listener_rule.host_based_routing.*.arn,aws_lb_listener_rule.host_based_routing_custom_listen_host.*.arn, aws_lb_listener_rule.host_based_routing_ssl_custom_listen_host_cognito_auth.*.arn, list())}"]
+}

--- a/modules/alb_handling/variables.tf
+++ b/modules/alb_handling/variables.tf
@@ -34,6 +34,11 @@ variable "lb_listener_arn_https" {
   default = ""
 }
 
+# redirect_http_to_https is set to create a http to https redirect
+variable "redirect_http_to_https" {
+  default = false
+}
+
 # target_type is the alb_target_group target, in case of EC2 it's instance, in case of FARGATE it's IP
 variable "target_type" {
   default = ""
@@ -89,3 +94,23 @@ variable "https_enabled" {
 
 # route53_record_identifier, sets the identifier for the route53 record in case the record type is ALIAS 
 variable "route53_record_identifier" {}
+
+# cognito_auth_enabled is set when cognito authentication is used for the https listener
+variable "cognito_auth_enabled" {
+  default = false
+}
+
+# cognito_user_pool_arn defines the cognito user pool arn for the added cognito authentication
+variable "cognito_user_pool_arn" {
+  default = ""
+}
+
+# cognito_user_pool_client_id defines the cognito_user_pool_client_id
+variable "cognito_user_pool_client_id" {
+  default = ""
+}
+
+# cognito_user_pool_domain sets the domain of the cognito_user_pool
+variable "cognito_user_pool_domain" {
+  default = ""
+}

--- a/variables.tf
+++ b/variables.tf
@@ -73,9 +73,32 @@ variable "load_balancing_properties" {
     Do we create listener rules for https
     https_enabled = true
 
+    Redirect http to https instead of serving http
+    redirect_http_to_https = false
+
     Do we want to create a subdomain for the service inside the Route53 zone
     create_route53_record = true
-    */
+
+    deregistration_delay = "300"
+
+    Creates a listener rule which redirects to https
+    redirect_http_to_https = false
+
+    cognito_auth_enabled is set when cognito authentication is used for the https listener
+    Important to have redirect_http_to_https set to true as http authentication is only added to the https listener
+
+    cognito_auth_enabled = false
+
+    cognito_user_pool_arn defines the cognito user pool arn for the added cognito authentication
+    cognito_user_pool_arn = ""
+
+    cognito_user_pool_client_id defines the cognito_user_pool_client_id
+    cognito_user_pool_client_id = ""
+
+    cognito_user_pool_domain sets the domain of the cognito_user_pool
+    cognito_user_pool_domain = ""
+
+    /
   }
 }
 
@@ -109,6 +132,26 @@ variable "default_load_balancing_properties_deregistration_delay" {
 
 variable "default_load_balancing_properties_https_enabled" {
   default = true
+}
+
+variable "default_load_balancing_properties_redirect_http_to_https" {
+  default = false
+}
+
+variable "default_load_balancing_properties_cognito_auth_enabled" {
+  default = false
+}
+
+variable "default_load_balancing_properties_cognito_user_pool_arn" {
+  default = ""
+}
+
+variable "default_load_balancing_properties_cognito_user_pool_client_id" {
+  default = ""
+}
+
+variable "default_load_balancing_properties_cognito_user_pool_domain" {
+  default = ""
 }
 
 variable "default_load_balancing_properties_route53_record_identifier" {

--- a/variables.tf
+++ b/variables.tf
@@ -97,8 +97,7 @@ variable "load_balancing_properties" {
 
     cognito_user_pool_domain sets the domain of the cognito_user_pool
     cognito_user_pool_domain = ""
-
-    /
+    */
   }
 }
 


### PR DESCRIPTION
## What
Adding Cognito Authentication for HTTP Traffic to the ECS Service, by adding another listener rule for https which is valid. Also add Http to https redirect listener_rule enabled with var.redirect_http_to_https .

## Why
Many  services or stuff under development used to be behind a Nginx with htaccess enabled. The ALB Authentication with Cognito delivers an almost similar experience and users will be quite easy to maintain. This saves another nginx docker service to maintain.

