### PR TITLE
lambda lookup policy dependency fix

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -135,13 +135,14 @@ resource "aws_cloudwatch_log_group" "app" {
 # This module is used to lookup the currently used ecs task definition
 #
 module "live_task_lookup" {
-  source                 = "./modules/live_task_lookup/"
-  create                 = "${var.create}"
-  ecs_cluster_id         = "${var.ecs_cluster_id}"
-  ecs_service_name       = "${var.name}"
-  container_name         = "${var.container_name}"
-  lambda_lookup_role_arn = "${module.iam.lambda_lookup_role_arn}"
-  lookup_type            = "${var.live_task_lookup_type}"
+  source                       = "./modules/live_task_lookup/"
+  create                       = "${var.create}"
+  ecs_cluster_id               = "${var.ecs_cluster_id}"
+  ecs_service_name             = "${var.name}"
+  container_name               = "${var.container_name}"
+  lambda_lookup_role_policy_id = "${module.iam.lambda_lookup_role_policy_id}"
+  lambda_lookup_role_arn       = "${module.iam.lambda_lookup_role_arn}"
+  lookup_type                  = "${var.live_task_lookup_type}"
 }
 
 #

--- a/modules/iam/output.tf
+++ b/modules/iam/output.tf
@@ -23,6 +23,11 @@ output "lambda_lookup_role_name" {
   value = "${element(concat(aws_iam_role.lambda_lookup.*.name, list("")), 0)}"
 }
 
+# policy ID of the lambda role, this to force dependency
+output "lambda_lookup_role_policy_id" {
+  value = "${element(concat(aws_iam_role_policy.lambda_lookup_policy.*.id, list("")), 0)}"
+}
+
 # IAM Role arn of the lambda lookup helper
 output "lambda_ecs_task_scheduler_role_arn" {
   value = "${element(concat(aws_iam_role.lambda_ecs_task_scheduler.*.arn, list("")), 0)}"

--- a/modules/live_task_lookup/main.tf
+++ b/modules/live_task_lookup/main.tf
@@ -1,3 +1,12 @@
+# In some cases the lambda is being invoked before the lamba policies have been added
+# This null_resources forces a dependency
+#
+resource "null_resource" "force_policy_dependency" {
+  triggers {
+    listeners = "${var.lambda_lookup_role_policy_id}"
+  }
+}
+
 #
 # lookup_type lambda
 #
@@ -13,8 +22,10 @@ resource "aws_lambda_function" "lambda_lookup" {
   tags             = "${var.tags}"
 
   lifecycle {
-    ignore_changes = ["filename"]
+    ignore_changes = ["*"]
   }
+
+  depends_on = ["null_resource.force_policy_dependency"]
 }
 
 data "aws_lambda_invocation" "lambda_lookup" {

--- a/modules/live_task_lookup/variables.tf
+++ b/modules/live_task_lookup/variables.tf
@@ -13,6 +13,9 @@ variable "ecs_cluster_id" {}
 # lambda_lookup_role_arn sets the role arn of the lookup_lambda
 variable "lambda_lookup_role_arn" {}
 
+# lambda_lookup_role_policy_id sets the id of the added policy to the lambda, this to force dependency
+variable "lambda_lookup_role_policy_id" {}
+
 # lookup_type sets the type of lookup, either 
 # * lambda - works during bootstrap and after bootstrap
 # * datasource - uses terraform datasources ( aws_ecs_service ) which won't work during bootstrap


### PR DESCRIPTION
## What 
A dependency for the lambda iam role policy adding.. the This to make sure that the datasource lookup is not crashing at invoke because the policy was not there yet.. Never happened to me before..

Ignore_policy for the lambda, if people want to update their zip they will need to taint it. This way updates of the zip lambda should not cause huge Terraform Plans as the datasource will not be used when the lambda is updated.