### PR TITLE
Adding Github templates Cloudposse style

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,7 @@
+## what
+* Describe the problem and how to reproduce it.
+* Describe the feature request or enhancement.
+
+## why
+* Explain why this is a problem and what is the expected behavior.
+* Explain why this feature request or enhancement is beneficial.

--- a/.github/PULL_REQUEST.md
+++ b/.github/PULL_REQUEST.md
@@ -1,0 +1,5 @@
+## what
+* Describe high-level what changed.
+
+## why
+* Provide the justifications for the changes.


### PR DESCRIPTION
## what

Adding GH templates ( https://docs.cloudposse.com/development/github/pull-requests/ ) for better issues and PRs. 

## why
Forces everyone to follow the same clear route.