### PR TITLE
Add Deployment Type

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -284,7 +284,7 @@ module "ecs_service" {
 
   # deployment_controller_type sets the deployment controller
   # rolling (default) maps to ECS, blue_green maps to CODE_DEPLOY
-  deployment_controller_type = "${var.deployment_controller_type[var.deployment_type]}"
+  deployment_controller_type = "${var.deployment_controller}"
 
   # deployment_maximum_percent sets the maximum size of the deployment in % of the normal size.
   deployment_maximum_percent = "${lookup(local.capacity_properties,"deployment_maximum_percent")}"

--- a/main.tf
+++ b/main.tf
@@ -282,9 +282,9 @@ module "ecs_service" {
 
   selected_task_definition = "${module.ecs_task_definition_selector.selected_task_definition_for_deployment}"
 
-  # deployment_controller_type sets the deployment controller
-  # rolling (default) maps to ECS, blue_green maps to CODE_DEPLOY
-  deployment_controller_type = "${var.deployment_controller}"
+  # deployment_controller_type sets the deployment type
+  # ECS for Rolling update, and CODE_DEPLOY for Blue/Green deployment via CodeDeploy
+  deployment_controller_type = "${var.deployment_controller_type}"
 
   # deployment_maximum_percent sets the maximum size of the deployment in % of the normal size.
   deployment_maximum_percent = "${lookup(local.capacity_properties,"deployment_maximum_percent")}"

--- a/main.tf
+++ b/main.tf
@@ -282,6 +282,10 @@ module "ecs_service" {
 
   selected_task_definition = "${module.ecs_task_definition_selector.selected_task_definition_for_deployment}"
 
+  # deployment_controller_type sets the deployment controller
+  # rolling (default) maps to ECS, blue_green maps to CODE_DEPLOY
+  deployment_controller_type = "${var.deployment_controller_type[var.deployment_type]}"
+
   # deployment_maximum_percent sets the maximum size of the deployment in % of the normal size.
   deployment_maximum_percent = "${lookup(local.capacity_properties,"deployment_maximum_percent")}"
 

--- a/modules/ecs_service/main.tf
+++ b/modules/ecs_service/main.tf
@@ -30,6 +30,10 @@ resource "aws_ecs_service" "app_with_lb_awsvpc" {
   deployment_maximum_percent         = "${var.deployment_maximum_percent}"
   deployment_minimum_healthy_percent = "${var.deployment_minimum_healthy_percent}"
 
+  deployment_controller {
+    type = "${var.deployment_controller_type}"
+  }
+
   load_balancer {
     target_group_arn = "${var.lb_target_group_arn}"
     container_name   = "${var.container_name}"
@@ -62,6 +66,10 @@ resource "aws_ecs_service" "app_with_lb_spread" {
 
   deployment_maximum_percent         = "${var.deployment_maximum_percent}"
   deployment_minimum_healthy_percent = "${var.deployment_minimum_healthy_percent}"
+
+  deployment_controller {
+    type = "${var.deployment_controller_type}"
+  }
 
   ordered_placement_strategy {
     field = "attribute:ecs.availability-zone"
@@ -104,6 +112,10 @@ resource "aws_ecs_service" "app_with_lb" {
   deployment_maximum_percent         = "${var.deployment_maximum_percent}"
   deployment_minimum_healthy_percent = "${var.deployment_minimum_healthy_percent}"
 
+  deployment_controller {
+    type = "${var.deployment_controller_type}"
+  }
+
   load_balancer {
     target_group_arn = "${var.lb_target_group_arn}"
     container_name   = "${var.container_name}"
@@ -131,6 +143,10 @@ resource "aws_ecs_service" "app" {
   deployment_maximum_percent         = "${var.deployment_maximum_percent}"
   deployment_minimum_healthy_percent = "${var.deployment_minimum_healthy_percent}"
 
+  deployment_controller {
+    type = "${var.deployment_controller_type}"
+  }
+
   lifecycle {
     ignore_changes = ["desired_count"]
   }
@@ -148,6 +164,10 @@ resource "aws_ecs_service" "app_awsvpc" {
 
   deployment_maximum_percent         = "${var.deployment_maximum_percent}"
   deployment_minimum_healthy_percent = "${var.deployment_minimum_healthy_percent}"
+
+  deployment_controller {
+    type = "${var.deployment_controller_type}"
+  }
 
   network_configuration {
     subnets         = ["${var.awsvpc_subnets}"]
@@ -204,6 +224,10 @@ resource "aws_ecs_service" "app_with_lb_awsvpc_with_service_registry" {
   deployment_maximum_percent         = "${var.deployment_maximum_percent}"
   deployment_minimum_healthy_percent = "${var.deployment_minimum_healthy_percent}"
 
+  deployment_controller {
+    type = "${var.deployment_controller_type}"
+  }
+
   load_balancer {
     target_group_arn = "${var.lb_target_group_arn}"
     container_name   = "${var.container_name}"
@@ -241,6 +265,10 @@ resource "aws_ecs_service" "app_with_lb_spread_with_service_registry" {
 
   deployment_maximum_percent         = "${var.deployment_maximum_percent}"
   deployment_minimum_healthy_percent = "${var.deployment_minimum_healthy_percent}"
+
+  deployment_controller {
+    type = "${var.deployment_controller_type}"
+  }
 
   ordered_placement_strategy {
     field = "attribute:ecs.availability-zone"
@@ -289,6 +317,10 @@ resource "aws_ecs_service" "app_with_lb_with_service_registry" {
   deployment_maximum_percent         = "${var.deployment_maximum_percent}"
   deployment_minimum_healthy_percent = "${var.deployment_minimum_healthy_percent}"
 
+  deployment_controller {
+    type = "${var.deployment_controller_type}"
+  }
+
   load_balancer {
     target_group_arn = "${var.lb_target_group_arn}"
     container_name   = "${var.container_name}"
@@ -322,6 +354,10 @@ resource "aws_ecs_service" "app_with_service_registry" {
   deployment_maximum_percent         = "${var.deployment_maximum_percent}"
   deployment_minimum_healthy_percent = "${var.deployment_minimum_healthy_percent}"
 
+  deployment_controller {
+    type = "${var.deployment_controller_type}"
+  }
+
   service_registries = {
     registry_arn   = "${aws_service_discovery_service.service.arn}"
     container_name = "${var.container_name}"
@@ -345,6 +381,10 @@ resource "aws_ecs_service" "app_awsvpc_with_service_registry" {
 
   deployment_maximum_percent         = "${var.deployment_maximum_percent}"
   deployment_minimum_healthy_percent = "${var.deployment_minimum_healthy_percent}"
+
+  deployment_controller {
+    type = "${var.deployment_controller_type}"
+  }
 
   network_configuration {
     subnets         = ["${var.awsvpc_subnets}"]

--- a/modules/ecs_service/variables.tf
+++ b/modules/ecs_service/variables.tf
@@ -33,6 +33,12 @@ variable "container_port" {}
 # scheduling_strategy defaults to Replica
 variable "scheduling_strategy" {}
 
+# ECS for Rolling update -> set deployment_maximum_percent and deployment_minimum_healthy_percent.
+# CODE_DEPLOY for Blue/Green deployment through AWS CodeDeploy
+variable "deployment_controller_type" {
+  default = "ECS"
+}
+
 # deployment_maximum_percent sets the maximum size of the total capacity in tasks in % compared to the normal capacity at deployment
 variable "deployment_maximum_percent" {}
 

--- a/modules/ecs_service/variables.tf
+++ b/modules/ecs_service/variables.tf
@@ -33,11 +33,9 @@ variable "container_port" {}
 # scheduling_strategy defaults to Replica
 variable "scheduling_strategy" {}
 
-# ECS for Rolling update -> set deployment_maximum_percent and deployment_minimum_healthy_percent.
-# CODE_DEPLOY for Blue/Green deployment through AWS CodeDeploy
-variable "deployment_controller_type" {
-  default = "ECS"
-}
+# deployment_controller_type sets the deployment type
+# ECS for Rolling update, and CODE_DEPLOY for Blue/Green deployment via CodeDeploy
+variable "deployment_controller_type" {}
 
 # deployment_maximum_percent sets the maximum size of the total capacity in tasks in % compared to the normal capacity at deployment
 variable "deployment_maximum_percent" {}

--- a/variables.tf
+++ b/variables.tf
@@ -59,9 +59,9 @@ variable "load_balancing_properties" {
   default = {}
 }
 
-# deployment_type defines deployment controller type.
-# Valid options: ECS (Default), CODE_DEPLOY
-variable "deployment_controller" {
+# deployment_controller_type sets the deployment type
+# ECS for Rolling update, and CODE_DEPLOY for Blue/Green deployment via CodeDeploy
+variable "deployment_controller_type" {
   default = "ECS"
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -59,6 +59,21 @@ variable "load_balancing_properties" {
   default = {}
 }
 
+# deployment_type defines deployment controller type.
+# rolling maps to ECS by, blue_green maps to CODE_DEPLOY
+variable "deployment_type" {
+  default = "rolling"
+  description = "Type of deployment controller. Valid values: rolling, blue_green"
+}
+
+variable "deployment_controller_type" {
+  type = "map"
+  default = {
+    rolling = "ECS"
+    blue_green = "CODE_DEPLOY"
+  }
+}
+
 /*
  Note that since Terraform doesn't support partial map defaults (see
  https://github.com/hashicorp/terraform/issues/16517), the default values here

--- a/variables.tf
+++ b/variables.tf
@@ -60,18 +60,9 @@ variable "load_balancing_properties" {
 }
 
 # deployment_type defines deployment controller type.
-# rolling maps to ECS by, blue_green maps to CODE_DEPLOY
-variable "deployment_type" {
-  default = "rolling"
-  description = "Type of deployment controller. Valid values: rolling, blue_green"
-}
-
-variable "deployment_controller_type" {
-  type = "map"
-  default = {
-    rolling = "ECS"
-    blue_green = "CODE_DEPLOY"
-  }
+# Valid options: ECS (Default), CODE_DEPLOY
+variable "deployment_controller" {
+  default = "ECS"
 }
 
 /*


### PR DESCRIPTION
### Added optional variable `deployment_type`

**ECS** (default) -- Default, Rolling deployment type.

**CODE_DEPLOY** -- Blue/Green deployment style, controller by AWS CodeDeploy
_must be set if you want to deploy your ECS Service via CodeDeploy_

Example:
```
module "nginx_service" {
...
deployment_controller_type = "CODE_DEPLOY"
...
}
```