### PR TITLE
Issue 33 add scheduled scaling

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -379,7 +379,6 @@ module "lambda_ecs_task_scheduler" {
   create = "${var.create && length(var.ecs_cron_tasks) > 0 ? true : false }"
 
   ecs_cluster_id = "${var.ecs_cluster_id}"
-
   container_name = "${var.container_name}"
 
   # ecs_service_name is derived from the actual ecs_service, this to force dependency at creation.
@@ -390,4 +389,20 @@ module "lambda_ecs_task_scheduler" {
 
   # lambda_ecs_task_scheduler_role_arn sets the role arn of the task scheduling lambda
   lambda_ecs_task_scheduler_role_arn = "${module.iam.lambda_ecs_task_scheduler_role_arn}"
+}
+
+# Module for task scheduling using cron or at expressions.
+module "ecs_scheduled_tasks" {
+  source = "./modules/ecs_scheduled_tasks"
+
+  cluster_name         = "${local.ecs_cluster_name}"
+  desired_max_capacity = "${lookup(local.capacity_properties,"desired_max_capacity")}"
+  desired_min_capacity = "${lookup(local.capacity_properties,"desired_min_capacity")}"
+  ecs_service_name     = "${module.ecs_service.ecs_service_name}"
+  resource_id          = "${length(var.scaling_properties) > 0 ? module.ecs_autoscaling.aws_appautoscaling_target_resource_id : ""}"
+  scalable_dimension   = "${length(var.scaling_properties) > 0 ? module.ecs_autoscaling.aws_appautoscaling_target_scalable_dimension : ""}"
+  service_namespace    = "${length(var.scaling_properties) > 0 ? module.ecs_autoscaling.aws_appautoscaling_target_service_namespace : ""}"
+  scaling_properties   = "${var.scaling_properties}"
+  schedule_scale_down  = "${var.schedule_scale_down != "" ? var.schedule_scale_down : ""}"
+  schedule_scale_up    = "${var.schedule_scale_up != "" ? var.schedule_scale_up : ""}"
 }

--- a/modules/ecs_autoscaling/outputs.tf
+++ b/modules/ecs_autoscaling/outputs.tf
@@ -1,0 +1,13 @@
+# These outputs are needed in order to avoid creating two app_autoscaling_target resources
+# and when using one we would need it's attributes.
+output "aws_appautoscaling_target_service_namespace" {
+  value = "${join("", aws_appautoscaling_target.target.*.service_namespace)}"
+}
+
+output "aws_appautoscaling_target_resource_id" {
+  value = "${join("", aws_appautoscaling_target.target.*.resource_id)}"
+}
+
+output "aws_appautoscaling_target_scalable_dimension" {
+  value = "${join("", aws_appautoscaling_target.target.*.scalable_dimension)}"
+}

--- a/modules/ecs_scheduled_tasks/main.tf
+++ b/modules/ecs_scheduled_tasks/main.tf
@@ -1,0 +1,40 @@
+locals {
+  cluster_plus_service_name = "${var.cluster_name}-${var.ecs_service_name}"
+}
+
+resource "aws_appautoscaling_target" "ecs" {
+  count              = "${(var.schedule_scale_up != "" || var.schedule_scale_down != "") && length(var.scaling_properties) == 0 ? 1 : 0}"
+  max_capacity       = "${var.desired_max_capacity}"
+  min_capacity       = "${var.desired_min_capacity}"
+  resource_id        = "service/${var.cluster_name}/${var.ecs_service_name}"
+  scalable_dimension = "ecs:service:DesiredCount"
+  service_namespace  = "ecs"
+}
+
+resource "aws_appautoscaling_scheduled_action" "down" {
+  count              = "${var.schedule_scale_down != "" ? 1 : 0}"
+  name               = "${local.cluster_plus_service_name}_scheduled_scale_down"
+  service_namespace  = "${length(var.scaling_properties) > 0 ? var.service_namespace : join(" ", aws_appautoscaling_target.ecs.*.service_namespace)}"
+  resource_id        = "${length(var.scaling_properties) > 0 ? var.resource_id : join(" ", aws_appautoscaling_target.ecs.*.resource_id)}"
+  scalable_dimension = "${length(var.scaling_properties) > 0 ? var.scalable_dimension : join(" ", aws_appautoscaling_target.ecs.*.scalable_dimension)}"
+  schedule           = "${var.schedule_scale_down}"
+
+  scalable_target_action {
+    min_capacity = "${var.scalable_target_action_min_capacity_down}"
+    max_capacity = "${var.scalable_target_action_max_capacity_down}"
+  }
+}
+
+resource "aws_appautoscaling_scheduled_action" "up" {
+  count              = "${var.schedule_scale_up != "" ? 1 : 0}"
+  name               = "${local.cluster_plus_service_name}_scheduled_scale_up"
+  service_namespace  = "${length(var.scaling_properties) > 0 ? var.service_namespace : join(" ", aws_appautoscaling_target.ecs.*.service_namespace)}"
+  resource_id        = "${length(var.scaling_properties) > 0 ? var.resource_id : join(" ", aws_appautoscaling_target.ecs.*.resource_id)}"
+  scalable_dimension = "${length(var.scaling_properties) > 0 ? var.scalable_dimension : join(" ", aws_appautoscaling_target.ecs.*.scalable_dimension)}"
+  schedule           = "${var.schedule_scale_up}"
+
+  scalable_target_action {
+    max_capacity = "${var.scalable_target_action_max_capacity_up != "" ? var.scalable_target_action_max_capacity_up : var.desired_max_capacity}"
+    min_capacity = "${var.scalable_target_action_min_capacity_up != "" ? var.scalable_target_action_max_capacity_up : var.desired_min_capacity}"
+  }
+}

--- a/modules/ecs_scheduled_tasks/variables.tf
+++ b/modules/ecs_scheduled_tasks/variables.tf
@@ -5,13 +5,13 @@ variable "cluster_name" {
 
 variable "schedule_scale_up" {
   type        = "string"
-  description = "Set the schedule with the at or the cron notation e.g. cron(* * ? * SAT-SUN *)"
+  description = "Set the schedule with the at, cron or rate expression e.g. cron(* * ? * SAT-SUN *)"
   default     = ""
 }
 
 variable "schedule_scale_down" {
   type        = "string"
-  description = "Set the schedule with the at or the cron notation e.g. cron(* * ? * SAT-SUN *)"
+  description = "Set the schedule with the at, cron or rate expression e.g. cron(* * ? * SAT-SUN *)"
   default     = ""
 }
 

--- a/modules/ecs_scheduled_tasks/variables.tf
+++ b/modules/ecs_scheduled_tasks/variables.tf
@@ -1,0 +1,79 @@
+variable "cluster_name" {
+  type        = "string"
+  description = "Get the ecs cluster name"
+}
+
+variable "schedule_scale_up" {
+  type        = "string"
+  description = "Set the schedule with the at or the cron notation e.g. cron(* * ? * SAT-SUN *)"
+  default     = ""
+}
+
+variable "schedule_scale_down" {
+  type        = "string"
+  description = "Set the schedule with the at or the cron notation e.g. cron(* * ? * SAT-SUN *)"
+  default     = ""
+}
+
+variable "ecs_service_name" {
+  type        = "string"
+  description = "Ecs service name"
+}
+
+variable "desired_min_capacity" {
+  type        = "string"
+  description = "The minimum capacity in tasks for this service"
+}
+
+variable "desired_max_capacity" {
+  type        = "string"
+  description = "The maximum capacity in tasks for this service"
+}
+
+variable "scalable_target_action_min_capacity_down" {
+  type        = "string"
+  description = "The min capacity of the scalable target when scaling down."
+  default     = 0
+}
+
+variable "scalable_target_action_max_capacity_down" {
+  type        = "string"
+  description = "The max capacity of the scalable target when scaling down."
+  default     = 0
+}
+
+variable "scalable_target_action_min_capacity_up" {
+  type        = "string"
+  description = "The max capacity of the scalable target when scaling up. Defaults to desired_min_capacity if not specified"
+  default     = ""
+}
+
+variable "scalable_target_action_max_capacity_up" {
+  type        = "string"
+  description = "The max capacity of the scalable target when scaling up. Defaults to desired_man_capacity if not specified"
+  default     = ""
+}
+
+variable "scaling_properties" {
+  type        = "list"
+  description = "Pass the scaling properties here to check if the autoscaling_app_target should be created"
+  default     = []
+}
+
+variable "service_namespace" {
+  type        = "string"
+  description = "If another autoscaling_app_target is created this variable is used to pass on the service_namespace from it"
+  default     = ""
+}
+
+variable "resource_id" {
+  type        = "string"
+  description = "If another autoscaling_app_target is created this variable is used to pass on the resource_id from it"
+  default     = ""
+}
+
+variable "scalable_dimension" {
+  type        = "string"
+  description = "If another autoscaling_app_target is created this variable is used to pass on the scalable_dimension from it"
+  default     = ""
+}

--- a/variables.tf
+++ b/variables.tf
@@ -413,3 +413,15 @@ variable "tags" {
   type        = "map"
   default     = {}
 }
+
+variable "schedule_scale_up" {
+  type        = "string"
+  description = "Set the schedule with the at or the cron notation e.g. cron(* * ? * SAT-SUN *)"
+  default     = ""
+}
+
+variable "schedule_scale_down" {
+  type        = "string"
+  description = "Set the schedule with the at or the cron notation e.g. cron(* * ? * SAT-SUN *)"
+  default     = ""
+}


### PR DESCRIPTION
Solves https://github.com/blinkist/terraform-aws-airship-ecs-service/issues/33

Add a sub module `ecs_scheduled_tasks` to be used for scheduled task scaling using cron, at or rate expressions. 
https://docs.aws.amazon.com/autoscaling/application/userguide/application-auto-scaling-scheduled-scaling.html

The following parameters need to be passed in order to activate this sub module
```hcl
  schedule_scale_down    = "cron(15 10 ? * 6L 2002-2005)"
  schedule_scale_up      = "cron(15 10 ? * 6L 2002-2005)"
```
It works in conjunction with the  existing sub module `ecs_autoscaling` by utlizing the `aws_appautoscaling_target` resource from it and using its attributes only if the `ecs_autoscaling` module is created.
