### PR TITLE
Adding documentation in the ecs repo itself

### DIFF
--- a/airship.tf/guide/ecs_service/README.md
+++ b/airship.tf/guide/ecs_service/README.md
@@ -1,0 +1,187 @@
+---
+sidebarDepth: 2
+---
+
+# ECS Service
+
+<mermaid/>
+
+## Introduction
+
+This module will create an ECS Service within an existing ECS Cluster and takes care of connecting it to a Load Balancer if configured to. It's highly configurable as there are many ways to operate an ECS Service. This Guide will go through most if not all of the configuration options the module supports. If you have questions, please join the #Airship channel on [Sweetops Slack](http://sweetops.slack.com) or create an issue [here](https://github.com/blinkist/terraform-aws-airship-ecs-service/issues)!
+
+## Contributing
+
+We are happy with contributions! If you see a bug or a lacking feature, feel free to submit a PR. Discussing your ideas first will of course help getting your PR through quicker! Please understand that the module should have as little breaking changes possible within this major release. With HCL2 ( Terraform 0.12 ) breaking changes seem to be inevitable and for this major release, refactoring with new ideas is of course much welcomed.
+
+## Naming Matters
+
+The name you choose for the ECS Service will be interpolated into different resources, for example the Application Load Balancer target groups. Certain AWS resources have a name limitation of 32 characters hence it's important to be economical with the amount of chars you allocate to the cluster name. Once a service has been created it's not possible to rename it, plan wisely.
+
+## Architecture
+
+ALB Connected ECS Service
+<div class="mermaid">
+graph LR
+    subgraph Module Scope
+    0
+    end
+    0[fa:fa-ban DNS Domain ecs_name.zone.tld]-->B[fa:fa-ban ALB]
+    B-->C[fa:fa-ban ALB HTTP Listener]
+    B-->D[fa:fa-ban ALB HTTPS Listener]
+    C-->E[fa:fa-ban LB Listener Rule for ecs_name.zone.tld]
+    D-->F[fa:fa-ban LB Listener Rule for ecs_name.zone.tld]
+    C-->L[fa:fa-ban LB Listener Rule for custom_domains optional]
+    D-->M[fa:fa-ban LB Listener Rule for custom_domains optional]
+    subgraph Module Scope
+    E-->G[fa:fa-ban Target Group]
+    F-->G[fa:fa-ban Target Group]
+    L-->G[fa:fa-ban Target Group]
+    M-->G[fa:fa-ban Target Group]
+    G-->H[fa:fa-ban ECS Service]
+    G-->I[fa:fa-ban ECS Service]
+    subgraph ECS Cluster
+    subgraph ECS Service
+    H[fa:fa-ban ECS Task N]
+    I[fa:fa-ban ECS Task N+1]
+    end
+    end
+    H-.->J[fa:fa-ban Task Definition:version]
+    I-.->J[fa:fa-ban Task Definition:version]
+    end
+</div>
+
+## Full Example
+
+```json
+module "demo_web" {
+  source  = "blinkist/airship-ecs-service/aws"
+  version = "0.9.1"
+
+  name   = "demo-web"
+
+  ecs_cluster_id = "${local.cluster_id}"
+
+  region = "${local.region}"
+
+  fargate_enabled = true
+
+  # scheduling_strategy = "REPLICA"
+
+  # AWSVPC Block, with awsvpc_subnets defined the network_mode for the ECS task definition will be awsvpc, defaults to bridge
+  awsvpc_enabled = true
+  awsvpc_subnets            = ["${module.vpc.private_subnets}"]
+  awsvpc_security_group_ids = ["${module.demo_sg.this_security_group_id}"]
+
+  # load_balancing_enabled sets if a load balancer will be attached to the ecs service / target group
+  load_balancing_type = "application"
+
+  # The ARN of the ALB, when left-out the service, will not be attached to a load-balance
+  load_balancing_properties_lb_arn                = "${module.alb_shared_services_ext.load_balancer_id}"
+  # https listener ARN
+  load_balancing_properties_lb_listener_arn_https = "${element(module.alb_shared_services_ext.https_listener_arns,0)}"
+
+  # http listener ARN
+  load_balancing_properties_lb_listener_arn       = "${element(module.alb_shared_services_ext.http_tcp_listener_arns,0)}"
+
+  # The VPC_ID the target_group is being created in
+  load_balancing_properties_lb_vpc_id             = "${module.vpc.vpc_id}"
+
+  # The route53 zone for which we create a subdomain
+  load_balancing_properties_route53_zone_id       = "${aws_route53_zone.shared_ext_services_domain.zone_id}"
+
+  # After which threshold in health check is the task marked as unhealthy, defaults to 3
+  # load_balancing_properties_unhealthy_threshold   = "3"
+
+  # load_balancing_properties_health_uri defines which health-check uri the target group needs to check on for health_check, defaults to /ping
+  # load_balancing_properties_health_uri = "/ping"
+
+  # The amount time for Elastic Load Balancing to wait before changing the state of a deregistering target from draining to unused.
+  # load_balancing_properties_deregistration_delay = "300"
+
+  # Creates a listener rule which redirects to https
+  # load_balancing_properties_redirect_http_to_https = false
+
+  # custom_listen_hosts defines extra listener rules to route to the ALB Targetgroup
+  custom_listen_hosts    = ["www.example.com"]
+
+  container_cpu    = 256
+  container_memory = 512
+  container_port   = 80
+
+  # force_bootstrap_container_image to true will force the deployment to use var.bootstrap_container_image as container_image
+  # if container_image is already deployed, no actual service update will happen
+  # force_bootstrap_container_image = false
+  bootstrap_container_image = "nginx:stable"
+
+  # Initial ENV Variables for the ECS Task definition
+  container_envvars  {
+       TASK_TYPE = "web"
+  }
+
+  # capacity_properties defines the size in task for the ECS Service.
+  # Without scaling enabled, desired_capacity is the only necessary property, defaults to 2
+  # With scaling enabled, desired_min_capacity and desired_max_capacity define the lower and upper boundary in task size
+  capacity_properties_desired_capacity     = "2"
+  capacity_properties_desired_min_capacity = "2"
+  capacity_properties_desired_max_capacity = "2"
+
+  # https://docs.aws.amazon.com/autoscaling/application/userguide/what-is-application-auto-scaling.html
+  scaling_properties = [
+    {
+      type               = "CPUUtilization"
+      direction          = "up"
+      evaluation_periods = "2"
+      observation_period = "300"
+      statistic          = "Average"
+      threshold          = "89"
+      cooldown           = "900"
+      adjustment_type    = "ChangeInCapacity"
+      scaling_adjustment = "1"
+    },
+    {
+      type               = "CPUUtilization"
+      direction          = "down"
+      evaluation_periods = "4"
+      observation_period = "300"
+      statistic          = "Average"
+      threshold          = "10"
+      cooldown           = "300"
+      adjustment_type    = "ChangeInCapacity"
+      scaling_adjustment = "-1"
+    },
+  ]
+
+  # ecs_cron_tasks holds a list of maps defining scheduled jobs
+  # when ecs_cron_tasks holds at least one 'job' a lambda will be created which will
+  # trigger jobs with the currently running task definition. The given command will be used
+  # to override the CMD in the dockerfile. The lambda will prepend this command with ["/bin/sh", "-c" ]
+  # ecs_cron_tasks = [{
+  #   # name of the scheduled task
+  #   job_name            = "vacuum_db"
+  #   # expression defined in
+  #   # http://docs.aws.amazon.com/AmazonCloudWatch/latest/events/ScheduledEvents.html
+  #   schedule_expression = "cron(0 12 * * ? *)"
+  #
+  #   # command defines the command which needs to run inside the docker container
+  #   command             = "/usr/local/bin/vacuum_db"
+  # }]
+
+
+  # The KMS Keys which can be used for kms:decrypt
+  kms_keys  = ["${module.global-kms.aws_kms_key_arn}", "${module.demo-kms.aws_kms_key_arn}"]
+
+  # The SSM paths for which the service will be allowed to ssm:GetParameter and ssm:GetParametersByPath on
+  #
+  # https://medium.com/@tdi/ssm-parameter-store-for-keeping-secrets-in-a-structured-way-53a25d48166a
+  # "arn:aws:ssm:region:123456:parameter/application/%s/*"
+  #TODO
+  ssm_paths = ["${module.global-kms.name}", "${module.demo-kms.name}"]
+
+  # s3_ro_paths define which paths on S3 can be accessed from the ecs service in read-only fashion.
+  s3_ro_paths = []
+
+  # s3_ro_paths define which paths on S3 can be accessed from the ecs service in read-write fashion.
+  s3_rw_paths = []
+}
+```

--- a/airship.tf/guide/ecs_service/deployment.md
+++ b/airship.tf/guide/ecs_service/deployment.md
@@ -1,0 +1,79 @@
+---
+sidebarDepth: 2
+---
+
+# Deployment & drift detection
+
+## Deployment
+
+The idea with the module is that third party software and pipelines are used to deploy docker image with. Unless configured different Terraform will only deploy the bootstrap_container_image the moment the ECS Service Module is being applied for the first time.
+
+Popular tools for deploying Docker images are:
+
+* [ECS Deploy](https://github.com/silinternational/ecs-deploy)
+* [AWS Codepipeline](https://aws.amazon.com/codepipeline/)
+* [Deploy fish](https://github.com/caltechads/deployfish)
+
+The parameter `bootstrap_container_image` defines the container image for the container definition for the first time. After the service has been deployed it will not be used anymore unless `force_bootstrap_container_image` is set to true.
+```json
+  # force_bootstrap_container_image to true will force the deployment to use var.bootstrap_container_image as container_image
+  # if container_image is already deployed, no actual service update will happen
+  # force_bootstrap_container_image = false
+  bootstrap_container_image = "nginx:stable"
+```
+
+<mermaid/>
+
+## Drift Detection
+
+*A diagram of the interaction between the submodules with the ECS Service Module.*
+
+<div class="mermaid">
+sequenceDiagram
+    ECS Module->>live_task_lookup: Retrieve image of running ECS Task
+    live_task_lookup->>live_task_lookup: Invoke lambda to check for current live task
+    live_task_lookup-->>ECS Module: live_image
+    ECS Module->>ecs_container_definition: create container def with live image or parameter image
+    ecs_container_definition-->>ECS Module: return container definition
+    ECS Module->>ecs_task_definition: create task definition with new container definition
+    ecs_task_definition-->>ECS Module:task version
+    ECS Module->>ecs_task_definition_selector: return the live task definition when no change has been made
+    ecs_task_definition_selector-->>ECS Module: live or new task definition version
+    ECS Module->>ecs_service: Update Service with given task definition version
+</div>
+
+
+When using the module for the first time, a Task Definition is created with a container definition. This container definition has the `bootstrap_container_image`, cpu and memory capacity, environment variables and other params defined inside the submodule : ecs_container_definition. 
+
+These deployment tools create a new Task Definition, by copying the current Task Definition in use and replacing the image with what is given as parameter. After creation of the new Task Definition, the ECS Service task definition attribute will be set to the newly created ECS Task definition. ECS takes care of the deployment without downtime, this can either be configured as rolling or something similar to a green/blue deployment.
+
+As updates happen outside of the Terraform State a so called drift takes place. The ECS Service in Terraform is still pointing to an older version of the Task definition. The ECS Module takes care of that by looking up the current active ECS Task definition. It grabs the running image from the live container definition and it creates a new Task Definition with the updated image. If there are no changes between the live task definition and the newly created one. The ECS Service will keep pointing to the live definition and no actual update takes place.
+
+
+## Policy for deployment
+
+The IAM User or IAM Role which updates the ECS Service with new Task Definitions need the following IAM Policy.
+```json
+data "aws_iam_policy_document" "ecs_deploy_permissions" {
+  statement {
+    effect = "Allow"
+
+    actions = [
+      "ecs:DeregisterTaskDefinition",
+      "ecs:DescribeServices",
+      "ecs:DescribeTaskDefinition",
+      "ecs:DescribeTasks",
+      "ecs:ListTasks",
+      "ecs:ListTaskDefinitions",
+      "ecs:RegisterTaskDefinition",
+      "ecs:StartTask",
+      "ecs:StopTask",
+      "ecs:UpdateService",
+      "iam:PassRole",
+    ]
+
+    resources = ["*"]
+  }
+}
+```
+

--- a/airship.tf/guide/ecs_service/ec2_specific.md
+++ b/airship.tf/guide/ecs_service/ec2_specific.md
@@ -1,0 +1,61 @@
+---
+sidebarDepth: 2
+---
+
+# EC2 Specific
+
+For EC2 Backed ECS Cluster nodes there are a few extra configuration possibilties.
+
+## Placement Strategy
+
+By default the ECS Scheduler is not placing the ECS Tasks of an ECS Cluster spread, in some cases this can lead to
+having a tasks belonging to one ECS Service placed on one EC2 instance, even when there are multiple EC2 Instances available.
+
+By enabling `with_placement_strategy` in the module, the ECS tasks are configured with the following spread.
+
+
+```json
+module "demo_web" {
+  ..
+  with_placement_strategy = true
+  ..
+}
+```
+
+Configured spread inside the ECS Service.
+
+```json
+ordered_placement_strategy {
+  field = "attribute:ecs.availability-zone"
+  type  = "spread"
+}
+
+ordered_placement_strategy {
+  field = "instanceId"
+  type  = "spread"
+}
+
+ordered_placement_strategy {
+  field = "memory"
+  type  = "binpack"
+}
+```
+
+## Scheduling Strategy
+
+The [Service Scheduler](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs_services.html#service_scheduler) is set to 'Replica' by default. The replica scheduling strategy places and maintains the desired number of tasks across your cluster. By default, the service scheduler spreads tasks across Availability Zones. You can use task placement strategies and constraints to customize task placement decisions. 
+
+The daemon scheduling strategy deploys exactly one task on each active container instance that meets all of the task placement constraints that you specify in your cluster. When using this strategy, there is no need to specify a desired number of tasks, a task placement strategy, or use Service Auto Scaling policies. For example, this can be helpful to run monitoring tools on the ECS Cluster where exactly one task is needed per instance.
+
+
+```json
+module "demo_web" {
+  ..
+  scheduling_strategy = "DAEMON"
+  ..
+}
+```
+
+## Volume Mounting
+
+TODO

--- a/airship.tf/guide/ecs_service/ecs_cron_tasks.md
+++ b/airship.tf/guide/ecs_service/ecs_cron_tasks.md
@@ -1,0 +1,49 @@
+---
+sidebarDepth: 2
+---
+
+# ECS Cron tasks
+
+## Introduction
+In many environments it's common to have cronjob like tasks. This module provide an easy way of configuring crontjobs for a running docker. The cronjobs will not be executed inside a running docker but a new task will be executed and the configured command will be ran.
+
+<mermaid/>
+<div class="mermaid">
+sequenceDiagram
+    Cloudwatch Event->>Lambda: Triggers Lambda at given rate
+    Lambda->>AWS API ECS: Asks for task definition of current running service
+    AWS API ECS-->>Lambda: task definition
+    Lambda->>AWS API ECS: Start Task Definition with given command
+</div>
+
+## Implementation
+
+The `ecs_cron_tasks` param holds a list of maps with information regarding the 'cron' jobs.
+
+```json
+   # ecs_cron_tasks holds a list of maps defining scheduled jobs
+   # when ecs_cron_tasks holds at least one 'job' a lambda will be created which will
+   # trigger jobs with the currently running task definition. The given command will be used
+   # to override the CMD in the dockerfile. The lambda will prepend this command with ["/bin/sh", "-c" ]
+   ecs_cron_tasks = [
+   {
+     # name of the scheduled task
+     job_name            = "vacuum_db"
+     # expression defined in
+     # http://docs.aws.amazon.com/AmazonCloudWatch/latest/events/ScheduledEvents.html
+     schedule_expression = "cron(0 12 * * ? *)"
+   
+     # command defines the command which needs to run inside the docker container
+     command             = "/usr/local/bin/vacuum_db"
+    },{
+     # name of the scheduled task
+     job_name            = "something_else"
+     # expression defined in
+     # http://docs.aws.amazon.com/AmazonCloudWatch/latest/events/ScheduledEvents.html
+     schedule_expression = "rate(10 minutes)"
+   
+     # command defines the command which needs to run inside the docker container
+     command             = "/usr/local/bin/something_else"
+   }
+   ]
+```

--- a/airship.tf/guide/ecs_service/healthcheck.md
+++ b/airship.tf/guide/ecs_service/healthcheck.md
@@ -1,0 +1,47 @@
+---
+sidebarDepth: 2
+---
+
+# Health Checks
+
+The AWS / ECS ecosystem has a few ways of discovering if a task is healthy or not.
+
+## Process
+
+The most basic health check is if the docker process is running. The moment the process of a docker dies the task is marked as unhealthy.
+
+## Load Balancer Checks
+
+In case of ALB the `health_uri` defines which URI the Application Load Balancer requests from the ECS Task. The task is marked healthy as long as a HTTP 200 OK is returned. In case it does not `unhealthy_threshold` sets the amount of errored requests before the task is marked unhealthy.
+
+```json
+      .. 
+      .. 
+      # After which threshold in health check is the task marked as unhealthy, defaults to 3
+      # load_balancing_properties_unhealthy_threshold   = "3"
+  
+      # load_balancing_properties_health_uri defines which health-check uri the target group needs to check on for health_check, defaults to /ping
+      # load_balancing_properties_health_uri = "/ping"
+  
+      # The amount time for Elastic Load Balancing to wait before changing the state of a deregistering target from draining to unused. The range is 0-3600 seconds.
+      load_balancing_properties_deregistration_delay = "10"
+    }
+```
+
+
+## Docker Healthcheck
+
+Docker provides a [HEALTHCHECK](https://docs.docker.com/engine/reference/builder/#healthcheck) directive to use from within docker. Without using the Dockerfile directive, the ECS Module has a parameter `container_healthcheck`.
+
+```json
+  container_healthcheck = {
+    command     = ["CMD-SHELL", "curl http://localhost:port/"]
+    interval    = "10"
+    startperiod = "120"
+    retries     = "3"
+    timeout     = "5"
+  }
+```
+:::warning
+All vars of the container_healthcheck map need to be filled or ECS will keep updating the Task Definition.
+:::

--- a/airship.tf/guide/ecs_service/iam.md
+++ b/airship.tf/guide/ecs_service/iam.md
@@ -1,0 +1,59 @@
+---
+sidebarDepth: 2
+---
+
+# Task IAM Role
+
+Task IAM Roles are a mechanism similar to EC2 Instance profiles. All available AWS SDK's can authenticate to AWS through the Task IAM Role without `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`. The policies attached to the Task IAM Role define which AWS services are accessible. For more information visit the [Developer Guide on Task IAM Roles](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-iam-roles.html)
+
+## Built-in policies
+This ECS Module takes care of creating an IAM role for the task and will also attach certain policies in case they are configured.
+
+### KMS
+[KMS](https://aws.amazon.com/kms/) (Key Management Service) is AWS' offering for envelope encryptiong next to the expensive CloudHSM. The module has as a list as input `kms_keys` which should be filled with the ARNs of KMS keys which the ECS Service then has allows kms:Decrypt on.
+
+```json
+    kms_keys  = ["${module.global-kms.aws_kms_key_arn}", "${module.demo-kms.aws_kms_key_arn}"]
+    # We can disable the policy creation by setting kms_enabled to true
+    # kms_enabled = false
+```
+
+### SSM
+The module has a list `ssm_paths` as input which the policy will interpolate as `parameter/application/%s/`. Applications can use the SSM Parameter Store to securely retrieve configuration parameters by ssm:GetParameter and ssm:GetParametersByPath on the paths provided. From Terraform
+
+```json
+    # The SSM paths for which the service will be allowed to ssm:GetParameter and ssm:GetParametersByPath on
+    # ssm_paths = ["shared_domain","application_specific_name"]
+    ssm_paths = ["${module.global_kms.name}", "${module.demo_kms.name}"]
+    # We can disable the policy creation by setting ssm_enabled to true
+    # ssm_enabled = false
+  }
+```
+
+### S3
+
+As it's very common that Applications have access to S3 for reading or writing access. The module has built-in policies for access to s3 buckets. A list of bucket names given as input to `s3_ro_paths` will automatically give Read-Only access to these buckets. In similar fashion `s3_rw_paths` can be used to give full access to a bucket.
+```json
+  # s3_ro_paths define which paths on S3 can be accessed from the ecs service in read-only fashion.
+  s3_ro_paths = []
+
+  # s3_ro_paths define which paths on S3 can be accessed from the ecs service in read-write fashion.
+  s3_rw_paths = []
+```
+
+## Add policies
+The module outputs the name and the arn of the IAM role. This way it is possible to add new policies to the IAM Role outside of the ECS Module.
+
+```json
+module "ecs_service_demo" {
+  ..
+  ..
+}
+
+resource "aws_iam_role_policy" "jobsystem_kinesis_events_stream_policy" {
+    name   = "Add access to Kinesis"
+    role   = "${module.ecs_service_demo.ecs_taskrole_name}"
+    policy = "${data.aws_iam_policy_document.jobsystem_kinesis_events_stream_policy.json}"
+}
+
+```

--- a/airship.tf/guide/ecs_service/load_balancing.md
+++ b/airship.tf/guide/ecs_service/load_balancing.md
@@ -1,0 +1,297 @@
+---
+sidebarDepth: 2
+---
+
+# Load balancing
+
+## types
+
+Through the ECS Module the ECS Service can be connected to different types of Load Balancers or no load balancer at all.
+
+The parameter `load_balancing_type` can be set to three options:
+* `application` - Application Load Balancer
+* `network` - Network Load Balancer
+* `none` - No load balancer
+
+### None
+
+When set to `none` the ECS Service is not connected to a load balancer and will most likely function as a type of worker. Without a load balancer checking health check URL's the process is only marked unhealthy the moment the process is killed or when the docker `HEALTHCHECK` is failing.
+
+```json
+module "demo_web" {
+  ..
+  load_balancing_type = "none"
+  ..
+}
+```
+
+<mermaid/>
+
+### Application LB
+
+The Appication Load Balancer ( ALB ) can forward traffic of multiple domain names to different ECS Services by creating so called [lb_listener_rules](https://www.terraform.io/docs/providers/aws/r/lb_listener_rule.html). This module can create listener rules on both the HTTP as the HTTPS listener. Based on the `host-header` ALB traffic will be forwarded to the right ECS Service. The Application Load Balancer is not transparent and traffic needs to be allowed. See [ECS Service networking](/guide/ecs_service/#ecs-service-networking) for more information.
+
+As many services can be connected to a single Applicaation Load Balancer, the load b
+
+
+By default the Module will create a record in the given `route53_zone_id` with the value of the name of the service, e.g. &lt;ecs_name&gt;.zone.tld. The parameter `route53_record_type` can be set to either `NONE`, `ALIAS` or `CNAME`. In case `NONE` is given, no record will be made inside the Route53 Zone. `ALIAS` has as advantage that multiple records with the same name can be made, this can help a migration to a different service at a later stage.
+
+For every host inside the module parameter `custom_listen_hosts` this module will create a listener rule pointing to your ECS Service. With the code snippet in mind of below, and if www.example.com is pointed to the ALB, traffic with www.example.com as host header will be be forwarded to the running ECS tasks of the service.
+
+```json
+module "demo_web" {
+  ..
+  ..
+  name = "airship-web"
+  ..
+  # load_balancing_enabled sets if a load balancer will be attached to the ecs service / target group
+  load_balancing_type = "application"
+  # The ARN of the ALB, when left-out the service, will not be attached to a load-balance
+  load_balancing_properties_lb_arn                = "${module.alb_shared_services_ext.load_balancer_id}"
+  # https listener ARN
+  load_balancing_properties_lb_listener_arn_https = "${element(module.alb_shared_services_ext.https_listener_arns,0)}"
+  # http listener ARN
+  load_balancing_properties_lb_listener_arn       = "${element(module.alb_shared_services_ext.http_tcp_listener_arns,0)}"
+  load_balancing_properties
+  # The VPC_ID the target_group is being created in
+  load_balancing_properties_lb_vpc_id             = "${module.vpc.vpc_id}"
+  # The route53 zone for which we create a subdomain
+  load_balancing_properties_route53_zone_id       = "${aws_route53_zone.shared_ext_services_domain.zone_id}"
+
+  # After which threshold in health check is the task marked as unhealthy, defaults to 3
+  load_balancing_properties_unhealthy_threshold   = "3"
+
+  # load_balancing_properties_unhealthy_threshold_health_uri defines which health-check uri the target group needs to check on for health_check, defaults to /ping
+  # load_balancing_properties_unhealthy_threshold_health_uri = "/ping"
+
+  # The amount time for Elastic Load Balancing to wait before changing the state of a deregistering target from draining to unused. The range is 0-3600 seconds.
+  load_balancing_properties_deregistration_delay = "10"
+
+  custom_listen_hosts    = ["www.example.com"]
+
+```
+
+This sample would create ...
+
+
+<div class="mermaid">
+graph LR
+    subgraph Module Scope
+    0
+    end
+    0[fa:fa-ban DNS Domain ecs_name.zone.tld]-->B[fa:fa-ban ALB]
+    B-->C[fa:fa-ban ALB HTTP Listener]
+    B-->D[fa:fa-ban ALB HTTPS Listener]
+    C-->E[fa:fa-ban LB Listener Rule for ecs_name.zone.tld]
+    D-->F[fa:fa-ban LB Listener Rule for ecs_name.zone.tld]
+    C-->L[fa:fa-ban LB Listener Rule for custom_domains optional]
+    D-->M[fa:fa-ban LB Listener Rule for custom_domains optional]
+    subgraph Module Scope
+    E-->G[fa:fa-ban Target Group]
+    F-->G[fa:fa-ban Target Group]
+    L-->G[fa:fa-ban Target Group]
+    M-->G[fa:fa-ban Target Group]
+    G-->H[fa:fa-ban ECS Service]
+    G-->I[fa:fa-ban ECS Service]
+    subgraph ECS Cluster
+    subgraph ECS Service
+    H[fa:fa-ban ECS Task N]
+    I[fa:fa-ban ECS Task N+1]
+    end
+    end
+    H-.->J[fa:fa-ban Task Definition:version]
+    I-.->J[fa:fa-ban Task Definition:version]
+    end
+</div>
+
+### Application LB HTTPS Redirect
+
+The ECS Module can also redirect HTTP traffic to HTTPS using [ALB Listener Rule - Redirect actions](https://docs.aws.amazon.com/elasticloadbalancing/latest/application/load-balancer-listeners.html#redirect-actions). Setting load_balancing_properties `redirect_http_to_https` to true will create LB Listener rules for the HTTP listener which won't forward traffic to the ECS Service but redirect the HTTP client to HTTPS.
+
+```json{20}
+module "demo_web" {
+  ..
+  ..
+  name = "airship-web"
+  ..
+  # load_balancing_enabled sets if a load balancer will be attached to the ecs service / target group
+  load_balancing_type = "application"
+  load_balancing_properties {
+    # The ARN of the ALB, when left-out the service, will not be attached to a load-balance
+    load_balancing_properties_lb_arn                = "${module.alb_shared_services_ext.load_balancer_id}"
+    # https listener ARN
+    load_balancing_properties_lb_listener_arn_https = "${element(module.alb_shared_services_ext.https_listener_arns,0)}"
+  
+    # The VPC_ID the target_group is being created in
+    load_balancing_properties_lb_vpc_id             = "${module.vpc.vpc_id}"
+  
+    # The route53 zone for which we create a subdomain
+    load_balancing_properties_route53_zone_id       = "${aws_route53_zone.shared_ext_services_domain.zone_id}"
+
+    load_balancing_properties_redirect_http_to_https = true
+  }
+  ..
+  ..
+```
+
+
+
+### Application LB Cognito Authentication
+
+Cognito provides an easy way to add authentication to any of your HTTP endpoints. A simple user pool can be created in Cognito which can be used to authenticate your users with. The following codeblock is a sample on how to create a cognito user pool.
+
+```json
+resource "aws_cognito_user_pool" "main" {
+  name = "testpool"
+
+  auto_verified_attributes = ["email"]
+
+  password_policy {
+    minimum_length    = 6
+    require_lowercase = false
+    require_uppercase = false
+    require_numbers   = false
+    require_symbols   = false
+  }
+
+  admin_create_user_config {
+    allow_admin_create_user_only = true
+    unused_account_validity_days = 7
+
+    invite_message_template {
+      email_message = "Your username is {username} and temporary password is {####}. "
+      email_subject = "Your temporary password"
+      sms_message   = "Your username is {username} and temporary password is {####}. "
+    }
+  }
+
+  verification_message_template {
+    default_email_option = "CONFIRM_WITH_LINK"
+  }
+}
+
+resource "aws_cognito_user_pool_domain" "pool" {
+  domain       = "testdomain"
+  user_pool_id = "${aws_cognito_user_pool.main.id}"
+}
+
+resource "aws_cognito_user_pool_client" "client" {
+  name                                 = "tfAWS"
+  generate_secret                      = "true"
+  supported_identity_providers         = ["COGNITO"]
+  allowed_oauth_flows_user_pool_client = true
+  allowed_oauth_flows                  = ["code"]
+  callback_urls                        = ["https://domain_of_your_http_endpoint/oauth2/idpresponse"]
+
+  allowed_oauth_scopes = [
+    "email",
+    "openid",
+    "profile",
+    "aws.cognito.signin.user.admin",
+  ]
+
+  user_pool_id = "${aws_cognito_user_pool.main.id}"
+}
+
+```
+
+After you have created the userpool, you can add a user like this. In this example, only Administrators can create new users.
+
+<img :src="$withBase('/cognito_create_user.png')" alt="create cognito user">
+
+
+
+::: warning
+Before the ECS Module can user the cognito user pool it needs to be applied with Terraform first.
+:::
+
+
+The `cognito_*` params take care of changing the ALB Listener to make sure the only authenticated users can visit the content. As cognito can only be applied to the https listener it's important to enable `redirect_http_to_https`.
+
+```json
+module "demo_web" {
+  ..
+  ..
+  name = "airship-web"
+  ..
+  # load_balancing_enabled sets if a load balancer will be attached to the ecs service / target group
+  load_balancing_type = "application"
+  # The ARN of the ALB, when left-out the service, will not be attached to a load-balance
+  load_balancing_properties_lb_arn                = "${module.alb_shared_services_ext.load_balancer_id}"
+  
+  # https listener ARN
+  load_balancing_properties_lb_listener_arn_https = "${element(module.alb_shared_services_ext.https_listener_arns,0)}"
+  
+  # http listener ARN
+  load_balancing_properties_lb_listener_arn       = "${element(module.alb_shared_services_ext.http_tcp_listener_arns,0)}"
+  
+  # The VPC_ID the target_group is being created in
+  load_balancing_properties_lb_vpc_id             = "${module.vpc.vpc_id}"
+  
+  # The route53 zone for which we create a subdomain
+  load_balancing_properties_route53_zone_id       = "${aws_route53_zone.shared_ext_services_domain.zone_id}"
+
+  load_balancing_properties_redirect_http_to_https = true
+
+  # cognito_auth_enabled is set when cognito authentication is used for the https listener
+  Important to have redirect_http_to_https set to true as http authentication is only added to the https listener
+
+  load_balancing_properties_cognito_auth_enabled = true
+
+  ## cognito_user_pool_arn defines the cognito user pool arn for the added cognito authentication
+  load_balancing_properties_cognito_user_pool_arn = "${aws_cognito_user_pool.main.arn}"
+
+  # cognito_user_pool_client_id defines the cognito_user_pool_client_id
+  load_balancing_properties_cognito_user_pool_client_id = "${aws_cognito_user_pool_client.client.id}"
+
+  # cognito_user_pool_domain sets the domain of the cognito_user_pool
+  load_balancing_properties_cognito_user_pool_domain = "${aws_cognito_user_pool_domain.pool.id}"
+  ..
+  ..
+```
+
+### Network LB ( NLB )
+
+The Network Load Balancer (NLB) forwards TCP Traffic transparently to the ECS Tasks of an ECS Service. For an existing NLB the ECS Module creates a new NLB-Listener with a new LB Target Group as default. By default the listener port is set to port 80. It's not mandatory to use the NLB togeter with awsvpc network mode.
+
+<div class="mermaid">
+graph LR
+    subgraph Module Scope
+    0
+    end
+    0[fa:fa-ban DNS Domain ecs_name.zone.tld]-->B[fa:fa-ban NLB]
+    B-->C[fa:fa-ban NLB Listener]
+    subgraph Module Scope
+    C-->D[fa:fa-ban Target Group]
+    D-->H[fa:fa-ban ECS Task N]
+    D-->I[fa:fa-ban ECS Task N+1]
+    subgraph ECS Cluster
+    subgraph ECS Service
+    H
+    I
+    end
+    end
+    H-.->J[fa:fa-ban Task Definition:version]
+    I-.->J[fa:fa-ban Task Definition:version]
+    end
+</div>
+
+```json
+module "demo_web" {
+    ..
+    ..
+    awsvpc_enabled = true
+    awsvpc_subnets            = ["${module.vpc.private_subnets}"]
+    awsvpc_security_group_ids = ["${module.demo_sg.this_security_group_id}"]
+
+
+    load_balancing_type = "network"
+    load_balancing_properties_lb_arn                = "${module.nlb.load_balancer_id}"
+    load_balancing_properties_lb_vpc_id             = "${module.vpc.vpc_id}"
+    load_balancing_properties_route53_zone_id       = "${aws_route53_zone.shared_ext_services_domain.zone_id}"
+    # load_balancing_properties_unhealthy_threshold   = "3"
+    # load_balancing_properties_nlb_listener_port sets the port of the lb_listener
+    # load_balancing_properties_nlb_listener_port = 80
+    ..
+    ..
+```

--- a/airship.tf/guide/ecs_service/logging.md
+++ b/airship.tf/guide/ecs_service/logging.md
@@ -1,0 +1,19 @@
+---
+sidebarDepth: 2
+---
+
+# Logging
+
+The ECS Services log to Cloudwatch and are by default kept for 14 days and unencrypted. It can be configured to have the logs encrypted by a given KMS key, together with a different retention.
+
+They log to the log-group with the following interpolated name: `<ecs_cluster_name>/<ecs_service_name>`
+
+
+```json
+module "demo_web" {
+  ..
+  # cloudwatch_kms_key = ".. arn of kms key"
+  # log_retention_in_days = "14"
+  ..
+}
+```

--- a/airship.tf/guide/ecs_service/networking.md
+++ b/airship.tf/guide/ecs_service/networking.md
@@ -1,0 +1,54 @@
+---
+sidebarDepth: 2
+---
+
+# Networking
+
+## Introduction
+
+<mermaid/>
+
+There are two types of networking for ECS. The ECS Task definitinion defines a network-mode, the two modes available are 'bridge' and 'awsvpc'.
+
+## Network-mode: bridge
+Bridge is only used for ECS Service which are run on top of EC2 Instances which joined the ECS Cluster. The service does not have their own Network Interface and will
+inherit the Networking of their Docker Host. As different different tasks cannot allocate the same port on the docker host, ECS uses [Dynamic Port Mapping](https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_PortMapping.html), which allocated ports in the ephemeral port range from 49153 through 65535. The Security Group of the EC2 Instance needs to allow traffic from the Load Balancer to these ports.
+
+<center><div class="mermaid">
+graph TD 
+    subgraph EC2 Instance
+    A[ECS Task A]-.->D
+    B[ECS Task A]-.->D
+    C[ECS Task B]-.->D
+    D{ENI}
+    end
+    D-.->E[Security Group X]
+    D-.->F[Security Group Y]
+    classDef green fill:#9f6,stroke:#333,stroke-width:2px;
+    class D green
+</div>
+</center>
+
+## Network-mode: awsvpc
+awsvpc network-mode is mandatory on Fargate and optional on EC2. The ECS Task will have its own ENI and will also have its own Security Group. The `container_port` parameter will also be used to expose the port on its network interface. A security group rule would need to allow traffic to this port. Using awsvpc with EC2 ECS is limited as the amount of available network interfaces per EC2 instance is extremely limited. [This](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-eni.html#AvailableIpPerENI) table shows the amount of ENI's available per instance type. Check out the [AWS Container Roadmap](https://github.com/aws/containers-roadmap/issues/7)!
+
+<center>
+<div class="mermaid">
+graph LR
+    subgraph ECS Task
+    D{ENI}
+    end
+    D-.->E[Security Group X]
+    D-.->F[Security Group Y]
+    classDef green fill:#9f6,stroke:#333,stroke-width:2px;
+    class D green
+</div>
+</center>
+
+::: tip
+For both network modes the security groups need to allow outgoing traffic to communicate with AWS, for example to pull ECR Docker images.
+:::
+
+::: warning Warning for Network Load Balancer (NLB) Users!
+A NLB acts transparantly and does not have a Security Group, this implies that ECS Services which need to allow traffic from a NLB need a wide open security group rule in case it needs to be reachable from the internet. It's advised to use awsvpc network mode for this as the service will have it's own Security Group then.
+:::

--- a/airship.tf/guide/ecs_service/scaling_capacity.md
+++ b/airship.tf/guide/ecs_service/scaling_capacity.md
@@ -1,0 +1,51 @@
+---
+sidebarDepth: 2
+---
+
+# Scaling and Capacity
+
+## Capacity
+
+The default capacity for services is defined by their min and max capacity. The min capacity defines the minimum amount of tasks the Scheduler need to keep running. The maximum capacity defines the upper limit. By default the min and max capacity is two.
+
+```json
+   # capacity_properties defines the size in task for the ECS Service.
+   # Without scaling enabled, desired_capacity is the only necessary property
+   # With scaling enabled, desired_min_capacity and desired_max_capacity define the lower and upper boundary in task size
+   capacity_properties_desired_capacity     = "2"
+   capacity_properties_desired_min_capacity = "2"
+   capacity_properties_desired_max_capacity = "2"
+```
+
+## Scaling
+
+Autoscaling properties can be set to adjust the amount of ECS Tasks per service based on certain cloudwatch metrics. The lower and upper capacity limit defined in `capacity_properties` stay valid.
+
+```json
+  # https://docs.aws.amazon.com/autoscaling/application/userguide/what-is-application-auto-scaling.html
+  scaling_properties = [
+    {
+      type               = "CPUUtilization"
+      direction          = "up"
+      evaluation_periods = "2"
+      observation_period = "300"
+      statistic          = "Average"
+      threshold          = "89"
+      cooldown           = "900"
+      adjustment_type    = "ChangeInCapacity"
+      scaling_adjustment = "1"
+    },
+    {
+      type               = "CPUUtilization"
+      direction          = "down"
+      evaluation_periods = "4"
+      observation_period = "300"
+      statistic          = "Average"
+      threshold          = "10"
+      cooldown           = "300"
+      adjustment_type    = "ChangeInCapacity"
+      scaling_adjustment = "-1"
+    },
+  ]
+```
+

--- a/airship.tf/guide/ecs_service/secrets_management.md
+++ b/airship.tf/guide/ecs_service/secrets_management.md
@@ -1,0 +1,34 @@
+---
+sidebarDepth: 2
+---
+
+# Secrets Management
+
+## Chamber
+
+The built in access to KMS and SSM make it possible to store application variables inside SSM. KMS is used to encrypt or decrypt the variables stored inside SSM.
+
+[Chamber](https://github.com/segmentio/chamber/) can be used inside Docker to retrieve the values from SSM and expose them as ENV vars to the application
+
+A modified CMD inside a Dockerfile which would normally runs `application_run.sh` will now first run chamber. And Chamber will exec `application_run.sh` and replace it's own PID doing so.
+
+```docker
+FROM example
+..
+..
+CMD exec chamber exec application/servicename -- application_run.sh
+```
+
+
+## Creating secrets for chamber
+
+Outside of the ECS Module you can create the secrets stored inside SSM.
+
+```json
+resource "aws_ssm_parameter" "environment" {
+  name   = "/application/servicename/environment"
+  type   = "SecureString"
+  key_id = "ARN of the KMS"
+  value  = "production"
+}
+```

--- a/airship.tf/guide/ecs_service/service_discovery.md
+++ b/airship.tf/guide/ecs_service/service_discovery.md
@@ -1,0 +1,46 @@
+---
+sidebarDepth: 2
+---
+
+# Service Discovery
+
+Please read [this](https://aws.amazon.com/blogs/aws/amazon-ecs-service-discovery/) article, on how Service Discovery can work for you.
+
+`aws_service_discovery_private_dns_namespace` creates the private dns namespace and route53 zone needed needed for the ECS Services to register to.
+
+```json
+resource "aws_service_discovery_private_dns_namespace" "namespace" {
+  name        = "namespace.local"
+  description = "Description"
+  vpc         = "${module.vpc.vpc_id}"
+}
+```
+
+<br/>
+<br/>
+<br/>
+
+The ECS Module has only implemented Service discovery for non-public namespaces. Only for AWSVPC networked ECS Services the `dns_type` A can be used, for bridge mode `SRV`.
+
+<br/>
+<br/>
+<br/>
+
+::: warning
+Apply Terraform first with the `aws_service_discovery_private_dns_namespace` resource before continuing.
+:::
+<br/>
+
+```json
+module "demo_web" {
+  ..
+  service_discovery_enabled = true
+
+  service_discovery_properties_namespace_id                         = "${aws_service_discovery_private_dns_namespace.namespace.id}"
+  service_discovery_properties_dns_ttl                              = "60"
+  service_discovery_properties_dns_type                             = "A"
+  service_discovery_properties_routing_policy                       = "MULTIVALUE"
+  service_discovery_properties_healthcheck_custom_failure_threshold = "1"
+  ..
+}
+```

--- a/main.tf
+++ b/main.tf
@@ -166,7 +166,7 @@ module "live_task_lookup" {
 module "container_definition" {
   source         = "./modules/ecs_container_definition/"
   container_name = "${var.container_name}"
-  command        = ["${var.command}"]
+  command        = ["${var.container_command}"]
 
   # if var.force_bootstrap_container_image is enabled, we always take the terraform param as container_image
   # otherwise we take the image from the datasource lookup
@@ -344,7 +344,7 @@ module "ecs_service" {
   # dns_type defaults to A (AWSVPC)
   service_discovery_dns_type = "${var.service_discovery_properties_dns_type}"
 
-  # routing_policy def
+  # service_discovery_properties_routing_policy
   service_discovery_routing_policy = "${var.service_discovery_properties_routing_policy}"
 
   # healthcheck_custom_failure_threshold needed, set to 1 by default

--- a/modules/ecs_container_definition/main.tf
+++ b/modules/ecs_container_definition/main.tf
@@ -40,7 +40,7 @@ locals {
     cpu                    = "${var.container_cpu}"
     essential              = "${var.essential}"
     entryPoint             = "${var.entrypoint}"
-    command                = "${var.command}"
+    command                = "${var.container_command}"
     workingDirectory       = "${var.working_directory}"
     readonlyRootFilesystem = "${var.readonly_root_filesystem}"
 

--- a/modules/ecs_container_definition/variables.tf
+++ b/modules/ecs_container_definition/variables.tf
@@ -28,7 +28,6 @@ variable "container_port" {
 
 variable "host_port" {
   description = "The port number on the container instance (host) to reserve for the container_port. If using containers in a task with the awsvpc or host network mode, the hostPort can either be left blank or set to the same value as the containerPort."
-  default     = 80
 }
 
 variable "protocol" {
@@ -61,7 +60,7 @@ variable "entrypoint" {
   default     = [""]
 }
 
-variable "command" {
+variable "container_command" {
   description = "The command that is passed to the container."
   default     = [""]
 }

--- a/variables.tf
+++ b/variables.tf
@@ -2,7 +2,8 @@
 # of the map is being defined. This is mitigated by using an extra set of default_* variables 
 
 variable "create" {
-  default = true
+  default     = true
+  description = "create is the variable used in all resources to conditionally create them"
 }
 
 variable "ecs_cluster_id" {
@@ -145,7 +146,7 @@ variable "load_balancing_properties_https_enabled" {
 
 variable "load_balancing_properties_deregistration_delay" {
   description = "load_balancing_properties_deregistration_delay sets the deregistration_delay for the targetgroup"
-  default     = true
+  default     = 300
 }
 
 variable "load_balancing_properties_route53_record_identifier" {
@@ -250,13 +251,15 @@ variable "container_healthcheck" {
   description = "healthcheck, describes the extra HEALTHCHECK for the container"
 }
 
-variable "command" {
-  type    = "list"
-  default = [""]
+variable "container_command" {
+  type        = "list"
+  default     = [""]
+  description = "container_command, describes the command for the container a a list, leaving default should run docker defined CMD"
 }
 
 variable "host_port" {
-  default = ""
+  default     = ""
+  description = "host_port, to be filled in to have a static host port mapping for non-awsvpc ecs, defaults to dynamic port mapping"
 }
 
 variable "scaling_properties" {
@@ -441,27 +444,33 @@ ecs_cron_tasks holds a list of maps defining the scheduled jobs which need to ru
 }
 
 variable "service_discovery_enabled" {
-  default = "false"
+  default     = "false"
+  description = "service_discovery_enabled enables service discovery"
 }
 
 variable "service_discovery_properties_namespace_id" {
-  default = ""
+  default     = ""
+  description = "service_discovery_properties_namespace_id sets the service discovery namespace"
 }
 
 variable "service_discovery_properties_dns_ttl" {
-  default = "60"
+  default     = "60"
+  description = "service_discovery_properties_dns_ttl sets the service discovery dns ttl"
 }
 
 variable "service_discovery_properties_dns_type" {
-  default = "A"
+  default     = "A"
+  description = "service_discovery_properties_dns_ttl sets the service discovery dns ttl"
 }
 
 variable "service_discovery_properties_routing_policy" {
-  default = "MULTIVALUE"
+  default     = "MULTIVALUE"
+  description = "The routing policy that you want to apply to all records that Route 53 creates when you register an instance and specify the service. Valid Values: MULTIVALUE, WEIGHTED"
 }
 
 variable "service_discovery_properties_healthcheck_custom_failure_threshold" {
-  default = "1"
+  default     = "1"
+  description = "The number of 30-second intervals that you want service discovery to wait before it changes the health status of a service instance. Maximum value of 10."
 }
 
 variable "tags" {


### PR DESCRIPTION
Documentation used to be in different GH repo, moving it here should make it easier to maintain.


