### PR TITLE
Travis cli install + proper config build trigger

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,12 +20,13 @@ script:
 
 after_script:
   - |
+    gem install travis
     if [ "$TRAVIS_BRANCH" == "master" ] ; then
       if git diff --name-only $TRAVIS_COMMIT_RANGE airship.tf | grep -qE '(\.md$)|(\.rst$)'
       then
         echo "There appear to be docs in this commit. Thank you.!"
         curl -LO https://raw.github.com/maartenvanderhoef/travis-dependent-builds/master/trigger.sh
         chmod +x trigger.sh
-        ./trigger.sh stephanmg downstream master $TRAVIS_ACCESS_TOKEN
+        ./trigger.sh doingcloudright airship.tf master $TRAVIS_ACCESS_TOKEN
       fi
     fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,8 +20,8 @@ script:
 
 after_script:
   - |
-    gem install travis
     if [ "$TRAVIS_BRANCH" == "master" ] ; then
+      gem install travis
       if git diff --name-only $TRAVIS_COMMIT_RANGE airship.tf | grep -qE '(\.md$)|(\.rst$)'
       then
         echo "There appear to be docs in this commit. Thank you.!"


### PR DESCRIPTION
## What 

Have doc creation travis of airship.tf triggered by PR

## Why

This small build workflow is needed to get docs built when ecs service is PR'ed.