### PR TITLE
Fix Terraform Registry issues with examples

### DIFF
--- a/examples/with_nlb/main.tf
+++ b/examples/with_nlb/main.tf
@@ -70,11 +70,6 @@ data "aws_network_interface" "nlb" {
   depends_on = ["aws_lb.this"]
 
   filter = {
-    name   = "description"
-    values = ["ELB ${aws_lb.this.arn_suffix}"]
-  }
-
-  filter = {
     name   = "subnet-id"
     values = ["${data.aws_subnet.selected.id}"]
   }
@@ -232,14 +227,12 @@ module "nlb_service" {
   route53_record_type  = "ALIAS"
 
   ## load_balancing_properties map defines the map for services hooked to a load balancer
-  load_balancing_properties = {
-    route53_zone_id      = "${aws_route53_zone.this.zone_id}"
-    route53_name         = "service-web"
-    lb_vpc_id            = "${data.aws_vpc.selected.id}"
-    target_group_port    = "${var.echo_port}"
-    nlb_listener_port    = "${var.echo_port}"
-    deregistration_delay = 0
-  }
+  load_balancing_properties_route53_zone_id      = "${aws_route53_zone.this.zone_id}"
+  load_balancing_properties_route53_name         = "service-web"
+  load_balancing_properties_lb_vpc_id            = "${data.aws_vpc.selected.id}"
+  load_balancing_properties_target_group_port    = "${var.echo_port}"
+  load_balancing_properties_nlb_listener_port    = "${var.echo_port}"
+  load_balancing_properties_deregistration_delay = 0
 
   # deployment_controller_type sets the deployment type
   # ECS for Rolling update, and CODE_DEPLOY for Blue/Green deployment via CodeDeploy


### PR DESCRIPTION
Registry won't publish currently.

```
Attribute redefined: The argument "filter" was already set at ./examples/with_nlb/main.tf:72,3-9. Each argument may be set only once. (in main.tf on line 77)
```