### PR TITLE
container_command breaking fix

### DIFF
--- a/modules/ecs_container_definition/variables.tf
+++ b/modules/ecs_container_definition/variables.tf
@@ -60,7 +60,7 @@ variable "entrypoint" {
   default     = [""]
 }
 
-variable "container_command" {
+variable "command" {
   description = "The command that is passed to the container."
   default     = [""]
 }


### PR DESCRIPTION
## What

Rename faulty `container_command` to `command`

## Why

Breaks the module.