### PR TITLE
Resolved NLB network interface ip lookup issue

### DIFF
--- a/examples/with_nlb/provider.tf
+++ b/examples/with_nlb/provider.tf
@@ -12,6 +12,7 @@ provider "aws" {
 }
 
 variable "region" {
+  ## Sorry I'm from this region
   default = "ap-southeast-2"
 }
 


### PR DESCRIPTION
# What:
The example had an issue where the security group that allows traffic from the NLB to the ECS cluster/service would fail if there was more than one service being added. This was due to the data source used to look up the service not filtering the EIP's correctly.
This filter has been updated and the resource now is added correctly.