### PR TITLE
Fetch ECS task ARN for IAM policy conditional

### DIFF
--- a/modules/iam/main.tf
+++ b/modules/iam/main.tf
@@ -224,6 +224,11 @@ resource "aws_iam_role_policy" "lambda_lookup_policy" {
   policy = "${data.aws_iam_policy_document.lambda_lookup_policy.0.json}"
 }
 
+# Fetch ECS cluster ARN for below policy
+data "aws_ecs_cluster" "default" {
+  cluster_name = "${var.ecs_cluster_id}"
+}
+
 # Policy for the Lambda Logging & ECS
 data "aws_iam_policy_document" "lambda_ecs_task_scheduler_policy" {
   count = "${var.create ? 1 : 0 }"
@@ -246,7 +251,7 @@ data "aws_iam_policy_document" "lambda_ecs_task_scheduler_policy" {
     condition {
       test     = "ArnEquals"
       variable = "ecs:cluster"
-      values   = ["${var.ecs_cluster_id}"]
+      values   = ["${data.aws_ecs_cluster.default.arn}"]
     }
   }
 


### PR DESCRIPTION
## what
It seems like AWS maybe doing some extra validation here but without 
this change, I am getting the below error [1]. As per the docs [2] when
using an ECS condition like ArnEquals, we need to ensure the value is
an actual valid ARN of the cluster, and not just the cluster id (name)

[1] `MalformedPolicyDocument: The policy failed legacy parsing`
[2] https://docs.aws.amazon.com/IAM/latest/UserGuide/list_amazonelasticcontainerservice.html

## testing

Have tested this branch and am no longer receiving the above error.