### PR TITLE
It seems like AWS maybe doing some extra validation here but without

### DIFF
--- a/modules/iam/main.tf
+++ b/modules/iam/main.tf
@@ -244,9 +244,9 @@ data "aws_iam_policy_document" "lambda_ecs_task_scheduler_policy" {
     resources = ["*"]
 
     condition {
-      test     = "ArnEquals"
+      test     = "ArnLike"
       variable = "ecs:cluster"
-      values   = ["${var.ecs_cluster_id}"]
+      values   = ["arn:aws:ecs:${var.region}:*:cluster/${var.ecs_cluster_id}"]
     }
   }
 


### PR DESCRIPTION
## what

this change, I am getting the below error [1]. As per the docs [2] when
using an ECS condition like ArnEquals, we need to ensure the value is
an actual valid ARN of the cluster, and not just the cluster id (name)

[1] `MalformedPolicyDocument: The policy failed legacy parsing`
[2] https://docs.aws.amazon.com/IAM/latest/UserGuide/list_amazonelasticcontainerservice.html