### PR TITLE
Allow pulling images from private Docker registry

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -189,6 +189,8 @@ module "container_definition" {
   container_envvars = "${var.container_envvars}"
   container_secrets = "${var.container_secrets}"
 
+  repository_credentials_secret_arn = "${var.repository_credentials_secret_arn}"
+
   container_docker_labels = "${var.container_docker_labels}"
 
   mountpoints = ["${var.mountpoints}"]

--- a/main.tf
+++ b/main.tf
@@ -181,6 +181,8 @@ module "container_definition" {
   container_memory             = "${var.container_memory}"
   container_memory_reservation = "${var.container_memory_reservation}"
 
+  container_init_process_enabled = "${var.container_init_process_enabled}"
+
   container_port = "${var.container_port}"
   host_port      = "${var.awsvpc_enabled ? var.container_port : var.host_port }"
 

--- a/modules/ecs_container_definition/main.tf
+++ b/modules/ecs_container_definition/main.tf
@@ -39,7 +39,16 @@ locals {
     without_port = []
   }
 
-  use_port = "${var.container_port == "" ? "without_port" : "with_port" }"
+  repository_credentials = {
+    with_credentials = {
+        credentialsParameter = "${var.repository_credentials_secret_arn}"
+    }
+
+    without_credentials = {}
+  }
+
+  use_port        = "${var.container_port == "" ? "without_port" : "with_port" }"
+  use_credentials = "${var.repository_credentials_secret_arn == "" ? "without_credentials" : "with_credentials" }"
 
   container_definitions = [{
     name                   = "${var.container_name}"
@@ -56,12 +65,13 @@ locals {
 
     privileged = "${var.privileged}"
 
-    hostname     = "${var.hostname}"
-    environment  = ["${null_resource.envvars_as_list_of_maps.*.triggers}"]
-    secrets      = ["${null_resource.secrets_as_list_of_maps.*.triggers}"]
-    mountPoints  = ["${var.mountpoints}"]
-    portMappings = "${local.port_mappings[local.use_port]}"
-    healthCheck  = "${var.healthcheck}"
+    hostname              = "${var.hostname}"
+    environment           = ["${null_resource.envvars_as_list_of_maps.*.triggers}"]
+    secrets               = ["${null_resource.secrets_as_list_of_maps.*.triggers}"]
+    mountPoints           = ["${var.mountpoints}"]
+    portMappings          = "${local.port_mappings[local.use_port]}"
+    healthCheck           = "${var.healthcheck}"
+    repositoryCredentials = "${local.repository_credentials[local.use_credentials]}"
 
     logConfiguration = {
       logDriver = "${var.log_driver}"

--- a/modules/ecs_container_definition/main.tf
+++ b/modules/ecs_container_definition/main.tf
@@ -73,6 +73,10 @@ locals {
     healthCheck           = "${var.healthcheck}"
     repositoryCredentials = "${local.repository_credentials[local.use_credentials]}"
 
+    linuxParameters = {
+      initProcessEnabled = "${var.container_init_process_enabled ? true : false }"
+    }
+
     logConfiguration = {
       logDriver = "${var.log_driver}"
       options   = "${var.log_options}"

--- a/modules/ecs_container_definition/variables.tf
+++ b/modules/ecs_container_definition/variables.tf
@@ -26,6 +26,11 @@ variable "container_port" {
   default     = 80
 }
 
+variable "container_init_process_enabled" {
+  description = "Should the container be run with initProcessEnabled (--init)"
+  default     = false
+}
+
 variable "host_port" {
   description = "The port number on the container instance (host) to reserve for the container_port. If using containers in a task with the awsvpc or host network mode, the hostPort can either be left blank or set to the same value as the containerPort."
 }

--- a/modules/ecs_container_definition/variables.tf
+++ b/modules/ecs_container_definition/variables.tf
@@ -163,3 +163,9 @@ variable "tags" {
   type        = "map"
   default     = {}
 }
+
+variable "repository_credentials_secret_arn" {
+  description = "ARN of Docker private registry credentials stored in secrets manager"
+  type        = "string"
+  default     = ""
+}

--- a/modules/iam/output.tf
+++ b/modules/iam/output.tf
@@ -3,6 +3,11 @@ output "ecs_task_execution_role_arn" {
   value = "${element(concat(aws_iam_role.ecs_task_execution_role.*.arn, list("")), 0)}"
 }
 
+# ecs_task_execution_role_arn outputs the Role-name for the ECS Task Execution role.
+output "ecs_task_execution_role_name" {
+  value = "${element(concat(aws_iam_role.ecs_task_execution_role.*.name, list("")), 0)}"
+}
+
 # ecs_taskrole_arn outputs the Role-Arn of the ECS Task
 output "ecs_taskrole_arn" {
   value = "${element(concat(aws_iam_role.ecs_tasks_role.*.arn, list("")), 0)}"

--- a/outputs.tf
+++ b/outputs.tf
@@ -14,6 +14,10 @@ output "task_execution_role_arn" {
   value = "${module.iam.ecs_task_execution_role_arn}"
 }
 
+output "task_execution_role_name" {
+  value = "${module.iam.ecs_task_execution_role_name}"
+}
+
 output "aws_ecs_task_definition_arn" {
   value = "${module.ecs_task_definition_selector.selected_task_definition_for_deployment}"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -506,3 +506,9 @@ variable "health_check_grace_period_seconds" {
   description = "The amount of seconds to wait before the first health check. Only relevant for load balanced apps. Default 5 minutes"
   default     = 300
 }
+
+variable "repository_credentials_secret_arn" {
+  description = "ARN of Docker private registry credentials stored in secrets manager"
+  type        = "string"
+  default     = ""
+}

--- a/variables.tf
+++ b/variables.tf
@@ -24,6 +24,11 @@ variable "container_secrets_enabled" {
   default     = false
 }
 
+variable "container_init_process_enabled" {
+  description = "Should the container be run with initProcessEnabled (--init)"
+  default     = false
+}
+
 variable "awsvpc_enabled" {
   default     = false
   description = "With awsvpc_enabled the network_mode for the ECS task definition will be awsvpc, defaults to bridge"


### PR DESCRIPTION
#### what

As per the documentation for Fargate using private docker registries[1]
this commit introduces a new variable
`repository_credentials_secret_arn` used to pass in the AWS Secrets
Manager path to your credentials secret. Note that this also requires
the ECS execution task role to have access to this secret.

[1] https://aws.amazon.com/blogs/compute/introducing-private-registry-authentication-support-for-aws-fargate/

#### testing

I have tested this with `repository_credentials_secret_arn` set and unset in my caller module.

__NOTE__ this PR does not change the execution task role to allow permissions for AWS Secrets Manager access and instead leaves up to the caller to ensure this by using the `task_execution_role_arn` output and attaching a policy outside of this module.