### PR TITLE
Only trigger ALB module if ALB != ‘none’

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -63,7 +63,7 @@ module "alb_handling" {
   cluster_name = "${local.ecs_cluster_name}"
 
   # Create defines if we need to create resources inside this module
-  create = "${var.create}"
+  create = "${var.create && var.load_balancing_type != "none" ? true : false}"
 
   # load_balancing_type sets the type, either "none", "application", or "network"
   load_balancing_type = "${var.load_balancing_type}"


### PR DESCRIPTION
#### what

If wanting to create an ECS task that does not have an ALB e.g. a 
scheduled task of some kind that doesn’t need an ALB, because we try and
do a lookup on a data source, I am currently getting [1]

If load_balancing_type is set to none, take it that we do *not* want to
create any resources in the ALB module.

[1] 
```
* module.ecs_service.module.alb_handling.data.aws_lb.main: 1 error occurred:
* module.ecs_service.module.alb_handling.data.aws_lb.main: data.aws_lb.main: Search returned 0 results, please revise so only one is returned
```