### PR TITLE
Health port variable

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -124,6 +124,9 @@ module "alb_handling" {
   # health_uri defines which health-check uri the target group needs to check on for health_check
   health_uri = "${var.load_balancing_properties_health_uri}"
 
+  # health_port defines port of the health-check
+  health_port= "${var.load_balancing_properties_health_port}"
+
   # The expected HTTP status for the health check to be marked healthy
   # You can specify multiple values (for example, "200,202") or a range of values (for example, "200-299")
   health_matcher = "${var.load_balancing_properties_health_matcher}"

--- a/modules/alb_handling/main.tf
+++ b/modules/alb_handling/main.tf
@@ -97,6 +97,7 @@ resource "aws_lb_target_group" "service" {
     path                = "${var.health_uri}"
     unhealthy_threshold = "${var.unhealthy_threshold}"
     healthy_threshold   = "${var.healthy_threshold}"
+    port                = "${var.health_port}"
   }
 }
 

--- a/modules/alb_handling/variables.tf
+++ b/modules/alb_handling/variables.tf
@@ -79,6 +79,11 @@ variable "health_uri" {
   default = ""
 }
 
+# port for the health check. Defaults to traffic-port
+variable "health_port" {
+  default = "traffic-port"
+}
+
 # The expected HTTP status for the health check to be marked healthy
 # You can specify multiple values (for example, "200,202") or a range of values (for example, "200-299")
 variable "health_matcher" {

--- a/variables.tf
+++ b/variables.tf
@@ -139,6 +139,11 @@ variable "load_balancing_properties_health_matcher" {
   default     = "200"
 }
 
+variable "load_balancing_properties_health_port" {
+  description = "health_port is the port of health uri to be checked by the ALB"
+  default     = "traffic-port"
+}
+
 variable "load_balancing_properties_unhealthy_threshold" {
   description = "The number of consecutive successful health checks required before considering an healthy target unhealthy"
   default     = "3"


### PR DESCRIPTION
Added a variable for specifying port for the Target Group health check
By default it will be `traffic-port` (as is)