### PR TITLE
Autoscaling actions

### DIFF
--- a/examples/with_scheduled_task/main.tf
+++ b/examples/with_scheduled_task/main.tf
@@ -36,8 +36,8 @@ module "scheduled_task" {
   tags                      = "${local.tags}"
 
   # Scheduled task configuration
-  is_scheduled_task         = true                           # Make this a scheduled task
-  scheduled_task_expression = "rate(1 minute)"               # Every minute
-  scheduled_task_count      = 1                              # The number of tasks to run
-  scheduled_task_name       = "my_task"                      # An optional uniquename for the event_rule. Defaults to the service name
+  is_scheduled_task         = true             # Make this a scheduled task
+  scheduled_task_expression = "rate(1 minute)" # Every minute
+  scheduled_task_count      = 1                # The number of tasks to run
+  scheduled_task_name       = "my_task"        # An optional uniquename for the event_rule. Defaults to the service name
 }

--- a/main.tf
+++ b/main.tf
@@ -125,7 +125,7 @@ module "alb_handling" {
   health_uri = "${var.load_balancing_properties_health_uri}"
 
   # health_port defines port of the health-check
-  health_port= "${var.load_balancing_properties_health_port}"
+  health_port = "${var.load_balancing_properties_health_port}"
 
   # The expected HTTP status for the health check to be marked healthy
   # You can specify multiple values (for example, "200,202") or a range of values (for example, "200-299")

--- a/modules/ecs_autoscaling/main.tf
+++ b/modules/ecs_autoscaling/main.tf
@@ -53,7 +53,8 @@ resource "aws_cloudwatch_metric_alarm" "alarm" {
     ServiceName = "${var.ecs_service_name}"
   }
 
-  alarm_actions = ["${aws_appautoscaling_policy.policy.*.arn[count.index]}"]
+  alarm_actions   = ["${aws_appautoscaling_policy.policy.*.arn[count.index]}"]
+  actions_enabled = true
 
-  depends_on = ["aws_appautoscaling_target.target"]
+  depends_on = ["aws_appautoscaling_target.target", "aws_appautoscaling_policy.policy"]
 }

--- a/variables.tf
+++ b/variables.tf
@@ -566,6 +566,6 @@ variable "scheduled_task_count" {
 }
 
 variable "scheduled_task_name" {
-  description = "The name of the scheduled_task event rule. If blank, this defaults to var.name".
+  description = "The name of the scheduled_task event rule. If blank, this defaults to var.name"
   default     = ""
 }


### PR DESCRIPTION
We've experienced problems with autoscaling alarms no longer get actions every time. This should fix the problem by adding policy to depend_on in autoscaling alarms.