### PR TITLE
Lambda runtime variable

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -167,6 +167,7 @@ module "live_task_lookup" {
   lambda_lookup_role_policy_id = "${module.iam.lambda_lookup_role_policy_id}"
   lambda_lookup_role_arn       = "${module.iam.lambda_lookup_role_arn}"
   lookup_type                  = "${var.live_task_lookup_type}"
+  lambda_runtime               = "${var.live_task_lookup_lambda_runtime}"
 }
 
 #
@@ -419,6 +420,8 @@ module "lambda_ecs_task_scheduler" {
 
   # lambda_ecs_task_scheduler_role_arn sets the role arn of the task scheduling lambda
   lambda_ecs_task_scheduler_role_arn = "${module.iam.lambda_ecs_task_scheduler_role_arn}"
+
+  lambda_runtime = "${var.lambda_ecs_task_scheduler_runtime}"
 }
 
 # ECS scheduled task configuration. This uses a CloudWatch rulle to start an ECS task at given intervals.

--- a/modules/lambda_ecs_task_scheduler/main.tf
+++ b/modules/lambda_ecs_task_scheduler/main.tf
@@ -16,7 +16,7 @@ resource "aws_lambda_function" "lambda_task_runner" {
   count            = "${var.create ? 1 : 0}"
   function_name    = "${local.identifier}"
   handler          = "index.handler"
-  runtime          = "nodejs8.10"
+  runtime          = "${var.lambda_runtime}"
   timeout          = 30
   filename         = "${path.module}/ecs_task_scheduler.zip"
   source_code_hash = "${data.archive_file.ecs_task_scheduler_zip.output_base64sha256}"

--- a/modules/lambda_ecs_task_scheduler/variables.tf
+++ b/modules/lambda_ecs_task_scheduler/variables.tf
@@ -38,3 +38,7 @@ variable "tags" {
   type    = "map"
   default = {}
 }
+
+variable "lambda_runtime" {
+  type = "string"
+}

--- a/modules/live_task_lookup/main.tf
+++ b/modules/live_task_lookup/main.tf
@@ -21,7 +21,7 @@ resource "aws_lambda_function" "lambda_lookup" {
   count            = "${var.create ? 1 : 0}"
   function_name    = "${basename(var.ecs_cluster_id)}-${var.ecs_service_name}-lambda-lookup"
   handler          = "index.handler"
-  runtime          = "nodejs8.10"
+  runtime          = "${var.lambda_runtime}"
   filename         = "${path.module}/lookup.zip"
   source_code_hash = "${data.archive_file.lookup_zip.output_base64sha256}"
   role             = "${var.lambda_lookup_role_arn}"

--- a/modules/live_task_lookup/variables.tf
+++ b/modules/live_task_lookup/variables.tf
@@ -16,7 +16,7 @@ variable "lambda_lookup_role_arn" {}
 # lambda_lookup_role_policy_id sets the id of the added policy to the lambda, this to force dependency
 variable "lambda_lookup_role_policy_id" {}
 
-# lookup_type sets the type of lookup, either 
+# lookup_type sets the type of lookup, either
 # * lambda - works during bootstrap and after bootstrap
 # * datasource - uses terraform datasources ( aws_ecs_service ) which won't work during bootstrap
 variable "lookup_type" {
@@ -33,10 +33,14 @@ variable "allowed_lookup_types" {
 
 locals {
   # validating the var.lookup_type input
-  test_lookup_type = "${lookup(var.allowed_lookup_types,var.lookup_type)}"
+  test_lookup_type = "${lookup(var.allowed_lookup_types, var.lookup_type)}"
 }
 
 # tags
 variable "tags" {
   default = {}
+}
+
+variable "lambda_runtime" {
+  type = "string"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -229,6 +229,12 @@ EOF
   default = "lambda"
 }
 
+variable "live_task_lookup_lambda_runtime" {
+  description = "Runtime version of live task lookup lambda"
+  type        = "string"
+  default     = "nodejs8.10"
+}
+
 variable "bootstrap_container_image" {
   description = "The docker image location"
 }
@@ -568,4 +574,10 @@ variable "scheduled_task_count" {
 variable "scheduled_task_name" {
   description = "The name of the scheduled_task event rule. If blank, this defaults to var.name".
   default     = ""
+}
+
+variable "lambda_ecs_task_scheduler_runtime" {
+  description = "Runtime version of ecs task scheduler lambda"
+  type        = "string"
+  default     = "nodejs8.10"
 }


### PR DESCRIPTION
This PR addresses https://github.com/blinkist/terraform-aws-airship-ecs-service/issues/84

Added variables for specifying runtime of lambdas for `live_task_lookup` module and `lambda_ecs_task_scheduler` module.

Default values are current