### PR TITLE
Update for Terraform 0.12

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 **/*.tfstate*
 **/.terraform
 
+# Editor files
+.dir-locals.el
+
 # Dynamically created by data.archive_file
 modules/live_task_lookup/lookup.zip
 modules/lambda_ecs_task_scheduler/ecs_task_scheduler.zip

--- a/examples/with_nlb/outputs.tf
+++ b/examples/with_nlb/outputs.tf
@@ -1,43 +1,44 @@
 output "ecs_taskrole_arn" {
-  value = "${module.nlb_service.ecs_taskrole_arn}"
+  value = module.nlb_service.ecs_taskrole_arn
 }
 
 output "ecs_taskrole_name" {
-  value = "${module.nlb_service.ecs_taskrole_name}"
+  value = module.nlb_service.ecs_taskrole_name
 }
 
 output "lb_target_group_arn" {
-  value = "${module.nlb_service.lb_target_group_arn}"
+  value = module.nlb_service.lb_target_group_arn
 }
 
 output "task_execution_role_arn" {
-  value = "${module.nlb_service.task_execution_role_arn}"
+  value = module.nlb_service.task_execution_role_arn
 }
 
 output "aws_ecs_task_definition_arn" {
-  value = "${module.nlb_service.aws_ecs_task_definition_arn}"
+  value = module.nlb_service.aws_ecs_task_definition_arn
 }
 
 output "aws_ecs_task_definition_family" {
-  value = "${module.nlb_service.aws_ecs_task_definition_family}"
+  value = module.nlb_service.aws_ecs_task_definition_family
 }
 
 output "lb_address" {
-  value = "${aws_lb.this.dns_name}"
+  value = aws_lb.this.dns_name
 }
 
 output "has_changed" {
-  value = "${module.nlb_service.has_changed}"
+  value = module.nlb_service.has_changed
 }
 
 output "cluster_id" {
-  value = "${module.ecs_cluster.cluster_id}"
+  value = module.ecs_cluster.cluster_id
 }
 
 output "zone_id" {
-  value = "${aws_route53_zone.this.zone_id}"
+  value = aws_route53_zone.this.zone_id
 }
 
 output "lb_arn" {
-  value = "${aws_lb.this.arn}"
+  value = aws_lb.this.arn
 }
+

--- a/examples/with_nlb/provider.tf
+++ b/examples/with_nlb/provider.tf
@@ -1,9 +1,9 @@
 terraform {
-  required_version = "~> 0.11.0"
+  required_version = ">= 0.12"
 }
 
 provider "aws" {
-  region                      = "${var.region}"
+  region                      = var.region
   skip_get_ec2_platforms      = true
   skip_metadata_api_check     = true
   skip_region_validation      = true

--- a/examples/with_scheduled_task/data.tf
+++ b/examples/with_scheduled_task/data.tf
@@ -1,19 +1,21 @@
 # Import references to some of the existing default VPC and subnet values.
 # Obviously, real world applications should never use these!
 
-data "aws_availability_zones" "available" {}
+data "aws_availability_zones" "available" {
+}
 
 data "aws_vpc" "selected" {
   default = true
 }
 
 data "aws_subnet" "selected" {
-  availability_zone = "${data.aws_availability_zones.available.names[0]}"
-  vpc_id            = "${data.aws_vpc.selected.id}"
+  availability_zone = data.aws_availability_zones.available.names[0]
+  vpc_id            = data.aws_vpc.selected.id
   default_for_az    = true
 }
 
 data "aws_security_group" "selected" {
   name   = "default"
-  vpc_id = "${data.aws_vpc.selected.id}"
+  vpc_id = data.aws_vpc.selected.id
 }
+

--- a/examples/with_scheduled_task/main.tf
+++ b/examples/with_scheduled_task/main.tf
@@ -1,18 +1,14 @@
-terraform {
-  required_version = "~> 0.11.0"
-}
-
 locals {
   region = "eu-west-1"
 
   tags = {
-    Environment = "${terraform.workspace}"
+    Environment = terraform.workspace
   }
 }
 
 resource "aws_ecs_cluster" "this" {
   name = "${terraform.workspace}-cluster"
-  tags = "${local.tags}"
+  tags = local.tags
 
   lifecycle {
     create_before_destroy = true
@@ -24,20 +20,20 @@ module "scheduled_task" {
   source = "../../"
 
   name                      = "${terraform.workspace}-scheduled-task"
-  ecs_cluster_id            = "${aws_ecs_cluster.this.id}"
-  region                    = "${local.region}"
+  ecs_cluster_id            = aws_ecs_cluster.this.id
+  region                    = local.region
   bootstrap_container_image = "hello-world:latest"
   container_cpu             = 256
   container_memory          = 512
   fargate_enabled           = true
   awsvpc_enabled            = true
-  awsvpc_subnets            = ["${data.aws_subnet.selected.id}"]
-  awsvpc_security_group_ids = ["${data.aws_security_group.selected.id}"]
-  tags                      = "${local.tags}"
+  awsvpc_subnets            = [data.aws_subnet.selected.id]
+  awsvpc_security_group_ids = [data.aws_security_group.selected.id]
+  tags                      = local.tags
 
   # Scheduled task configuration
-  is_scheduled_task         = true                           # Make this a scheduled task
-  scheduled_task_expression = "rate(1 minute)"               # Every minute
-  scheduled_task_count      = 1                              # The number of tasks to run
-  scheduled_task_name       = "my_task"                      # An optional uniquename for the event_rule. Defaults to the service name
+  is_scheduled_task         = true             # Make this a scheduled task
+  scheduled_task_expression = "rate(1 minute)" # Every minute
+  scheduled_task_count      = 1                # The number of tasks to run
+  scheduled_task_name       = "my_task"        # An optional uniquename for the event_rule. Defaults to the service name
 }

--- a/examples/with_scheduled_task/provider.tf
+++ b/examples/with_scheduled_task/provider.tf
@@ -1,5 +1,9 @@
+terraform {
+  required_version = ">= 0.12"
+}
+
 provider "aws" {
-  region                      = "${local.region}"
+  region                      = local.region
   skip_get_ec2_platforms      = true
   skip_metadata_api_check     = true
   skip_region_validation      = true
@@ -18,3 +22,4 @@ provider "null" {
 provider "template" {
   version = "~> 2.1"
 }
+

--- a/examples/with_secrets/main.tf
+++ b/examples/with_secrets/main.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "~> 0.11.0"
+  required_version = ">= 0.12"
 }
 
 locals {
@@ -7,7 +7,7 @@ locals {
 }
 
 provider "aws" {
-  region                      = "${local.region}"
+  region                      = local.region
   skip_get_ec2_platforms      = true
   skip_metadata_api_check     = true
   skip_region_validation      = true
@@ -16,10 +16,11 @@ provider "aws" {
 }
 
 locals {
-  remote_account_id = "${data.aws_caller_identity.current.account_id}"
+  remote_account_id = data.aws_caller_identity.current.account_id
 }
 
-data "aws_caller_identity" "current" {}
+data "aws_caller_identity" "current" {
+}
 
 data "aws_vpc" "selected" {
   default = true
@@ -38,25 +39,25 @@ resource "aws_ssm_parameter" "password" {
 }
 
 module "ecs-base" {
-  source = "../with_nlb"     # Reuse the infrastructure defined in the "with_nlb" example :)
-  region = "${local.region}"
+  source = "../with_nlb"
+  region = local.region
 }
 
 module "secret_service" {
   source = "../../"
 
   name                                        = "${terraform.workspace}-secrets"
-  ecs_cluster_id                              = "${module.ecs-base.cluster_id}"
-  region                                      = "${local.region}"
+  ecs_cluster_id                              = module.ecs-base.cluster_id
+  region                                      = local.region
   bootstrap_container_image                   = "nginx:stable"
   container_cpu                               = 256
   container_memory                            = 128
   container_port                              = 80
   load_balancing_type                         = "network"
-  load_balancing_properties_route53_zone_id   = "${module.ecs-base.zone_id}"
-  load_balancing_properties_lb_vpc_id         = "${data.aws_vpc.selected.id}"
+  load_balancing_properties_route53_zone_id   = module.ecs-base.zone_id
+  load_balancing_properties_lb_vpc_id         = data.aws_vpc.selected.id
   load_balancing_properties_nlb_listener_port = 80
-  load_balancing_properties_lb_arn            = "${module.ecs-base.lb_arn}"
+  load_balancing_properties_lb_arn            = module.ecs-base.lb_arn
 
   # Enable container secrets and add two parameters. The first is stored in a "remote" account, the other is stored locally. 
   container_secrets_enabled = true
@@ -71,6 +72,7 @@ module "secret_service" {
   ssm_paths   = ["myapp/dev"]
 
   tags = {
-    Environment = "${terraform.workspace}"
+    Environment = terraform.workspace
   }
 }
+

--- a/examples/without_elb/data.tf
+++ b/examples/without_elb/data.tf
@@ -1,16 +1,18 @@
-data "aws_availability_zones" "available" {}
+data "aws_availability_zones" "available" {
+}
 
 data "aws_vpc" "selected" {
   default = true
 }
 
 data "aws_subnet" "selected" {
-  availability_zone = "${data.aws_availability_zones.available.names[0]}"
-  vpc_id            = "${data.aws_vpc.selected.id}"
+  availability_zone = data.aws_availability_zones.available.names[0]
+  vpc_id            = data.aws_vpc.selected.id
   default_for_az    = true
 }
 
 data "aws_security_group" "selected" {
   name   = "default"
-  vpc_id = "${data.aws_vpc.selected.id}"
+  vpc_id = data.aws_vpc.selected.id
 }
+

--- a/examples/without_elb/main.tf
+++ b/examples/without_elb/main.tf
@@ -3,8 +3,9 @@ locals {
 }
 
 module "cluster" {
-  source  = "blinkist/airship-ecs-cluster/aws"
-  version = "0.5.1"
+  # source  = "blinkist/airship-ecs-cluster/aws"
+  # version = "v1.0.0"
+  source = "github.com/blinkist/terraform-aws-airship-ecs-cluster?ref=v1.0.0" # Terraform registry doesn't have v1.0.0 yet
 
   name                    = "${terraform.workspace}-cluster"
   create_roles            = false
@@ -15,12 +16,12 @@ module "service" {
   source = "../.."
 
   name                                          = "${terraform.workspace}-service"
-  region                                        = "${local.region}"
+  region                                        = local.region
   fargate_enabled                               = true
-  ecs_cluster_id                                = "${module.cluster.cluster_id}"
+  ecs_cluster_id                                = module.cluster.cluster_id
   awsvpc_enabled                                = true
-  awsvpc_subnets                                = ["${data.aws_subnet.selected.id}"]
-  awsvpc_security_group_ids                     = ["${data.aws_security_group.selected.id}"]
+  awsvpc_subnets                                = [data.aws_subnet.selected.id]
+  awsvpc_security_group_ids                     = [data.aws_security_group.selected.id]
   load_balancing_type                           = "none"
   load_balancing_properties_route53_record_type = "NONE"
   container_cpu                                 = 256
@@ -28,14 +29,16 @@ module "service" {
   capacity_properties_desired_capacity          = 1
   capacity_properties_desired_min_capacity      = 1
   capacity_properties_desired_max_capacity      = 1
-  bootstrap_container_image                     = "nginx:latest"                             # Obviously not a good candiate for a service without an ELB, but this is just a demo ;)
+  bootstrap_container_image                     = "nginx:latest" # Obviously not a good candiate for a service without an ELB, but this is just a demo ;)
 
-  # Without the ELB health check, you should provide either a health check in the Docker image or ECS. The one below is an example of the latter.
-  container_healthcheck = {
-    command     = ["CMD-SHELL", "curl http://localhost/"]
-    interval    = 10
-    startperiod = 120
-    retries     = 3
-    timeout     = 5
-  }
+  # # Without the ELB health check, you should provide either a health check in the Docker image or ECS. The one below is an example of the latter.
+  # # TODO: Doesn't work with TF 0.12, because all map elements must have the same type.
+  # container_healthcheck = {
+  #   command     = ["CMD-SHELL", "curl http://localhost/"]
+  #   interval    = 10
+  #   startperiod = 120
+  #   retries     = 3
+  #   timeout     = 5
+  # }
 }
+

--- a/examples/without_elb/provider.tf
+++ b/examples/without_elb/provider.tf
@@ -1,5 +1,9 @@
+terraform {
+  required_version = ">= 0.12"
+}
+
 provider "aws" {
-  region  = "${local.region}"
+  region  = local.region
   version = "~> 2.26"
 }
 

--- a/main.tf
+++ b/main.tf
@@ -223,7 +223,8 @@ module "container_definition" {
 
   mountpoints = var.mountpoints
 
-  healthcheck = var.container_healthcheck
+  healthcheck_cmd     = var.container_healthcheck_cmd
+  healthcheck_timings = var.container_healthcheck_timings
 
   log_options = {
     "awslogs-region"        = var.region

--- a/main.tf
+++ b/main.tf
@@ -53,6 +53,10 @@ module "iam" {
   # ssm_paths define which SSM paths the ecs_service can access
   ssm_paths = var.ssm_paths
 
+  # The container uses Secrets Manager secrets and needs a task
+  # execution role to get access to them
+  secretsmanager_enabled = var.container_secrets_enabled
+
   # repository_credentials_secret_arn is the Secrets Manager secret
   # containing credentials for an external Docker repo
   secretsmanager_secret_arns = local.secret_arns
@@ -65,9 +69,6 @@ module "iam" {
 
   # In case Fargate is enabled an extra role needs to be added
   fargate_enabled = var.fargate_enabled
-
-  # The container uses secrets and needs a task execution role to get access to them
-  container_secrets_enabled = var.container_secrets_enabled
 
   # If this is a scheduled task, cloudwatch needs permission to start the task
   is_scheduled_task = var.is_scheduled_task

--- a/main.tf
+++ b/main.tf
@@ -226,6 +226,7 @@ module "container_definition" {
 
   container_port = var.container_port
   host_port      = var.awsvpc_enabled ? var.container_port : var.host_port
+  extra_ports    = var.extra_ports
 
   hostname = var.awsvpc_enabled ? "" : var.name
 

--- a/main.tf
+++ b/main.tf
@@ -335,6 +335,9 @@ module "ecs_service" {
   # awsvpc_security_group_ids defines the vpc_security_group_ids for an awsvpc module
   awsvpc_security_group_ids = var.awsvpc_security_group_ids
 
+  # assign_public_ip is whether to assign a public IP address to an awsvpc service
+  assign_public_ip = var.assign_public_ip
+
   # lb_target_group_arn sets the arn of the target_group the service needs to connect to
   lb_target_group_arn = module.alb_handling.lb_target_group_arn
 

--- a/main.tf
+++ b/main.tf
@@ -114,6 +114,9 @@ module "alb_handling" {
 
   healthy_threshold = var.load_balancing_properties_healthy_threshold
 
+  # if http_enabled is true, listener rules are made for a non-HTTPS listener
+  http_enabled = var.load_balancing_properties_http_enabled
+
   # if https_enabled is true, listener rules are made for the ssl listener
   https_enabled = var.load_balancing_properties_https_enabled
 

--- a/main.tf
+++ b/main.tf
@@ -73,6 +73,9 @@ module "iam" {
   # If this is a scheduled task, cloudwatch needs permission to start the task
   is_scheduled_task = var.is_scheduled_task
 
+  # If we're using the Lambda-based task scheduler, create a role and policy for it
+  task_scheduler_enabled = length(var.ecs_cron_tasks) > 0
+
   # Propagate tags to IAM resources
   tags = local.tags
 }

--- a/main.tf
+++ b/main.tf
@@ -1,12 +1,16 @@
+terraform {
+  required_version = ">= 0.12"
+}
+
 locals {
-  ecs_cluster_name = "${basename(var.ecs_cluster_id)}"
-  launch_type      = "${var.fargate_enabled ? "FARGATE" : "EC2" }"
+  ecs_cluster_name = basename(var.ecs_cluster_id)
+  launch_type      = var.fargate_enabled ? "FARGATE" : "EC2"
 
   name_map = {
     "Name" = "${local.ecs_cluster_name}-${var.name}"
   }
 
-  tags = "${merge(var.tags, local.name_map)}"
+  tags = merge(var.tags, local.name_map)
 }
 
 #
@@ -19,42 +23,42 @@ module "iam" {
   name = "${local.ecs_cluster_name}-${var.name}"
 
   # Create defines if any resources need to be created inside the module
-  create = "${var.create}"
+  create = var.create
 
   # cluster_id
-  ecs_cluster_id = "${var.ecs_cluster_id}"
+  ecs_cluster_id = var.ecs_cluster_id
 
   # Region ..
-  region = "${var.region}"
+  region = var.region
 
   # kms_enabled sets whether this ecs_service should be able to access the given KMS keys.
   # Defaults to true; if no kms_paths are given, set this to false.
-  kms_enabled = "${var.kms_enabled}"
+  kms_enabled = var.kms_enabled
 
   # kms_keys define which KMS keys this ecs_service can access.
-  kms_keys = "${var.kms_keys}"
+  kms_keys = var.kms_keys
 
   # ssm_enabled sets whether this ecs_service should be able to access the given SSM paths.
   # Defaults to true; if no ssm_paths are given, set this to false.
-  ssm_enabled = "${var.ssm_enabled}"
+  ssm_enabled = var.ssm_enabled
 
   # ssm_paths define which SSM paths the ecs_service can access
-  ssm_paths = "${var.ssm_paths}"
+  ssm_paths = var.ssm_paths
 
   # s3_ro_paths define which paths on S3 can be accessed from the ecs service in read-only fashion.
-  s3_ro_paths = "${var.s3_ro_paths}"
+  s3_ro_paths = var.s3_ro_paths
 
   # s3_rw_paths define which paths on S3 can be accessed from the ecs service in read-write fashion.
-  s3_rw_paths = "${var.s3_rw_paths}"
+  s3_rw_paths = var.s3_rw_paths
 
   # In case Fargate is enabled an extra role needs to be added
-  fargate_enabled = "${var.fargate_enabled}"
+  fargate_enabled = var.fargate_enabled
 
   # The container uses secrets and needs a task execution role to get access to them
-  container_secrets_enabled = "${var.container_secrets_enabled}"
+  container_secrets_enabled = var.container_secrets_enabled
 
   # If this is a scheduled task, cloudwatch needs permission to start the task
-  is_scheduled_task = "${var.is_scheduled_task}"
+  is_scheduled_task = var.is_scheduled_task
 }
 
 #
@@ -62,97 +66,97 @@ module "iam" {
 module "alb_handling" {
   source = "./modules/alb_handling/"
 
-  name         = "${var.name}"
-  cluster_name = "${local.ecs_cluster_name}"
+  name         = var.name
+  cluster_name = local.ecs_cluster_name
 
   # Create defines if we need to create resources inside this module
-  create = "${var.create && var.load_balancing_type != "none" ? true : false}"
+  create = var.create && var.load_balancing_type != "none" ? true : false
 
   # load_balancing_type sets the type, either "none", "application", or "network"
-  load_balancing_type = "${var.load_balancing_type}"
+  load_balancing_type = var.load_balancing_type
 
   # lb_vpc_id sets the VPC ID of where the LB resides
-  lb_vpc_id = "${var.load_balancing_properties_lb_vpc_id}"
+  lb_vpc_id = var.load_balancing_properties_lb_vpc_id
 
   # lb_arn defines the arn of the LB
-  lb_arn = "${var.load_balancing_properties_lb_arn}"
+  lb_arn = var.load_balancing_properties_lb_arn
 
   # lb_listener_arn is the arn of the listener ( HTTP )
-  lb_listener_arn = "${var.load_balancing_properties_lb_listener_arn}"
+  lb_listener_arn = var.load_balancing_properties_lb_listener_arn
 
   # lb_listener_arn_https is the arn of the listener ( HTTPS )
-  lb_listener_arn_https = "${var.load_balancing_properties_lb_listener_arn_https}"
+  lb_listener_arn_https = var.load_balancing_properties_lb_listener_arn_https
 
   # nlb_listener_port sets the listener port of the nlb listener
-  nlb_listener_port = "${var.load_balancing_properties_nlb_listener_port}"
+  nlb_listener_port = var.load_balancing_properties_nlb_listener_port
 
   # target_group_port sets the port of the target group, by default 80 
-  target_group_port = "${var.load_balancing_properties_target_group_port}"
+  target_group_port = var.load_balancing_properties_target_group_port
 
   # unhealthy_threshold defines the threashold for the target_group after which a service is seen as unhealthy.
-  unhealthy_threshold = "${var.load_balancing_properties_unhealthy_threshold}"
+  unhealthy_threshold = var.load_balancing_properties_unhealthy_threshold
 
-  healthy_threshold = "${var.load_balancing_properties_healthy_threshold}"
+  healthy_threshold = var.load_balancing_properties_healthy_threshold
 
   # if https_enabled is true, listener rules are made for the ssl listener
-  https_enabled = "${var.load_balancing_properties_https_enabled}"
+  https_enabled = var.load_balancing_properties_https_enabled
 
   # Sets the deregistration_delay for the targetgroup
-  deregistration_delay = "${var.load_balancing_properties_deregistration_delay}"
+  deregistration_delay = var.load_balancing_properties_deregistration_delay
 
   # route53_record_type sets the record type of the route53 record, can be ALIAS, CNAME or NONE,  defaults to ALIAS
   # In case of NONE no record will be made
-  route53_record_type = "${var.is_scheduled_task ? "NONE" : var.load_balancing_properties_route53_record_type}"
+  route53_record_type = var.is_scheduled_task ? "NONE" : var.load_balancing_properties_route53_record_type
 
   # Sets the zone in which the sub-domain will be added for this service
-  route53_zone_id = "${var.load_balancing_properties_route53_zone_id}"
+  route53_zone_id = var.load_balancing_properties_route53_zone_id
 
   # Sets name for the sub-domain, we default to *name
-  route53_name = "${var.load_balancing_properties_route53_custom_name == "" ? var.name : var.load_balancing_properties_route53_custom_name}"
+  route53_name = var.load_balancing_properties_route53_custom_name == "" ? var.name : var.load_balancing_properties_route53_custom_name
 
   # route53_a_record_identifier sets the identifier of the weighted Alias A record
-  route53_record_identifier = "${var.load_balancing_properties_route53_record_identifier}"
+  route53_record_identifier = var.load_balancing_properties_route53_record_identifier
 
   # custom_listen_hosts will be added as a host route rule as aws_lb_listener_rule to the given service e.g. www.domain.com -> Service
-  custom_listen_hosts = "${var.load_balancing_properties_custom_listen_hosts}"
+  custom_listen_hosts = var.load_balancing_properties_custom_listen_hosts
 
-  custom_listen_hosts_count = "${var.load_balancing_properties_custom_listen_hosts_count}"
+  custom_listen_hosts_count = var.load_balancing_properties_custom_listen_hosts_count
 
   # redirect_http_to_https creates lb listeners which redirect incoming http traffic to https
-  redirect_http_to_https = "${var.load_balancing_properties_redirect_http_to_https}"
+  redirect_http_to_https = var.load_balancing_properties_redirect_http_to_https
 
   # health_uri defines which health-check uri the target group needs to check on for health_check
-  health_uri = "${var.load_balancing_properties_health_uri}"
+  health_uri = var.load_balancing_properties_health_uri
 
   # health_port defines port of the health-check
-  health_port= "${var.load_balancing_properties_health_port}"
+  health_port = var.load_balancing_properties_health_port
 
   # The expected HTTP status for the health check to be marked healthy
   # You can specify multiple values (for example, "200,202") or a range of values (for example, "200-299")
-  health_matcher = "${var.load_balancing_properties_health_matcher}"
+  health_matcher = var.load_balancing_properties_health_matcher
 
   # target_type is the alb_target_group target, in case of EC2 it's instance, in case of FARGATE it's IP
-  target_type = "${var.awsvpc_enabled ? "ip" : "instance"}"
+  target_type = var.awsvpc_enabled ? "ip" : "instance"
 
   # cognito_auth_enabled is set when cognito authentication is used for the https listener
-  cognito_auth_enabled = "${var.load_balancing_properties_cognito_auth_enabled}"
+  cognito_auth_enabled = var.load_balancing_properties_cognito_auth_enabled
 
   # cognito_user_pool_arn defines the cognito user pool arn for the added cognito authentication
-  cognito_user_pool_arn = "${var.load_balancing_properties_cognito_user_pool_arn}"
+  cognito_user_pool_arn = var.load_balancing_properties_cognito_user_pool_arn
 
   # cognito_user_pool_client_id defines the cognito_user_pool_client_id
-  cognito_user_pool_client_id = "${var.load_balancing_properties_cognito_user_pool_client_id}"
+  cognito_user_pool_client_id = var.load_balancing_properties_cognito_user_pool_client_id
 
   # cognito_user_pool_domain sets the domain of the cognito_user_pool
-  cognito_user_pool_domain = "${var.load_balancing_properties_cognito_user_pool_domain}"
+  cognito_user_pool_domain = var.load_balancing_properties_cognito_user_pool_domain
 }
 
 ###### CloudWatch Logs
 resource "aws_cloudwatch_log_group" "app" {
-  count             = "${var.create ? 1 : 0}"
+  count             = var.create ? 1 : 0
   name              = "${local.ecs_cluster_name}/${var.name}"
-  retention_in_days = "${var.log_retention_in_days}"
-  kms_key_id        = "${var.cloudwatch_kms_key}"
+  retention_in_days = var.log_retention_in_days
+  kms_key_id        = var.cloudwatch_kms_key
 }
 
 #
@@ -160,14 +164,14 @@ resource "aws_cloudwatch_log_group" "app" {
 #
 module "live_task_lookup" {
   source                       = "./modules/live_task_lookup/"
-  create                       = "${var.create}"
-  ecs_cluster_id               = "${var.ecs_cluster_id}"
-  ecs_service_name             = "${var.name}"
-  container_name               = "${var.container_name}"
-  lambda_lookup_role_policy_id = "${module.iam.lambda_lookup_role_policy_id}"
-  lambda_lookup_role_arn       = "${module.iam.lambda_lookup_role_arn}"
-  lookup_type                  = "${var.live_task_lookup_type}"
-  lambda_runtime               = "${var.live_task_lookup_lambda_runtime}"
+  create                       = var.create
+  ecs_cluster_id               = var.ecs_cluster_id
+  ecs_service_name             = var.name
+  container_name               = var.container_name
+  lambda_lookup_role_policy_id = module.iam.lambda_lookup_role_policy_id
+  lambda_lookup_role_arn       = module.iam.lambda_lookup_role_arn
+  lookup_type                  = var.live_task_lookup_type
+  lambda_runtime               = var.live_task_lookup_lambda_runtime
 }
 
 #
@@ -175,45 +179,44 @@ module "live_task_lookup" {
 #
 module "container_definition" {
   source            = "./modules/ecs_container_definition/"
-  container_name    = "${var.container_name}"
-  container_command = ["${var.container_command}"]
+  container_name    = var.container_name
+  container_command = [var.container_command]
 
   # if var.force_bootstrap_container_image is enabled, we always take the terraform param as container_image
   # otherwise we take the image from the datasource lookup
   # when the lookup has '<ECS_SERVICE_DOES_NOT_EXIST_YET>' as result, the bootstrap image is taken
-  container_image = "${var.force_bootstrap_container_image ? var.bootstrap_container_image :
-                         ( module.live_task_lookup.image == "<ECS_SERVICE_DOES_NOT_EXIST_YET>" ? var.bootstrap_container_image : module.live_task_lookup.image )}"
+  container_image = var.force_bootstrap_container_image ? var.bootstrap_container_image : module.live_task_lookup.image == "<ECS_SERVICE_DOES_NOT_EXIST_YET>" ? var.bootstrap_container_image : module.live_task_lookup.image
 
-  container_cpu                = "${var.container_cpu}"
-  container_memory             = "${var.container_memory}"
-  container_memory_reservation = "${var.container_memory_reservation}"
+  container_cpu                = var.container_cpu
+  container_memory             = var.container_memory
+  container_memory_reservation = var.container_memory_reservation
 
-  container_init_process_enabled = "${var.container_init_process_enabled}"
+  container_init_process_enabled = var.container_init_process_enabled
 
-  ulimit_name       = "${var.container_ulimit_name}"
-  ulimit_soft_limit = "${var.container_ulimit_soft_limit}"
-  ulimit_hard_limit = "${var.container_ulimit_hard_limit}"
+  ulimit_name       = var.container_ulimit_name
+  ulimit_soft_limit = var.container_ulimit_soft_limit
+  ulimit_hard_limit = var.container_ulimit_hard_limit
 
-  container_port = "${var.container_port}"
-  host_port      = "${var.awsvpc_enabled ? var.container_port : var.host_port }"
+  container_port = var.container_port
+  host_port      = var.awsvpc_enabled ? var.container_port : var.host_port
 
-  hostname = "${var.awsvpc_enabled == 1 ? "" : var.name}"
+  hostname = var.awsvpc_enabled ? "" : var.name
 
-  container_envvars = "${var.container_envvars}"
-  container_secrets = "${var.container_secrets}"
+  container_envvars = var.container_envvars
+  container_secrets = var.container_secrets
 
-  repository_credentials_secret_arn = "${var.repository_credentials_secret_arn}"
+  repository_credentials_secret_arn = var.repository_credentials_secret_arn
 
-  container_docker_labels = "${var.container_docker_labels}"
+  container_docker_labels = var.container_docker_labels
 
-  mountpoints = ["${var.mountpoints}"]
+  mountpoints = var.mountpoints
 
-  healthcheck = "${var.container_healthcheck}"
+  healthcheck = var.container_healthcheck
 
   log_options = {
-    "awslogs-region"        = "${var.region}"
-    "awslogs-group"         = "${element(concat(aws_cloudwatch_log_group.app.*.name, list("")), 0)}"
-    "awslogs-stream-prefix" = "${var.name}"
+    "awslogs-region"        = var.region
+    "awslogs-group"         = element(concat(aws_cloudwatch_log_group.app.*.name, [""]), 0)
+    "awslogs-stream-prefix" = var.name
   }
 }
 
@@ -223,44 +226,44 @@ module "container_definition" {
 module "ecs_task_definition" {
   source = "./modules/ecs_task_definition/"
 
-  create = "${var.create}"
+  create = var.create
 
   # The name of the task_definition (generally, a combination of the cluster name and the service name)
   name = "${local.ecs_cluster_name}-${var.name}"
 
-  cluster_name = "${local.ecs_cluster_name}"
+  cluster_name = local.ecs_cluster_name
 
-  container_definitions = "${module.container_definition.json}"
+  container_definitions = module.container_definition.json
 
   # awsvpc_enabled sets if the ecs task definition is awsvpc 
-  awsvpc_enabled = "${var.awsvpc_enabled}"
+  awsvpc_enabled = var.awsvpc_enabled
 
   # fargate_enabled sets if the ecs task definition has launch_type FARGATE
-  fargate_enabled = "${var.fargate_enabled}"
+  fargate_enabled = var.fargate_enabled
 
   # Sets the task cpu needed for fargate when enabled
-  cpu = "${var.fargate_enabled ? var.container_cpu : "" }"
+  cpu = var.fargate_enabled ? var.container_cpu : ""
 
   # Sets the task memory which is mandatory for Fargate, option for EC2
-  memory = "${var.fargate_enabled ? var.container_memory : "" }"
+  memory = var.fargate_enabled ? var.container_memory : ""
 
   # ecs_taskrole_arn sets the IAM role of the task.
-  ecs_taskrole_arn = "${module.iam.ecs_taskrole_arn}"
+  ecs_taskrole_arn = module.iam.ecs_taskrole_arn
 
   # ecs_task_execution_role_arn sets the task-execution role needed for FARGATE. This role is also empty in case of EC2
-  ecs_task_execution_role_arn = "${module.iam.ecs_task_execution_role_arn}"
+  ecs_task_execution_role_arn = module.iam.ecs_task_execution_role_arn
 
   # Launch type, either EC2 or FARGATE
-  launch_type = "${local.launch_type}"
+  launch_type = local.launch_type
 
   # region, needed for Logging.. 
-  region = "${var.region}"
+  region = var.region
 
   # a Docker volume to add to the task
-  docker_volume = "${var.docker_volume}"
+  docker_volume = var.docker_volume
 
   # list of host paths to add as volumes to the task
-  host_path_volumes = "${var.host_path_volumes}"
+  host_path_volumes = var.host_path_volumes
 }
 
 #
@@ -272,23 +275,23 @@ module "ecs_task_definition_selector" {
   source = "./modules/ecs_task_definition_selector/"
 
   # Create defines if we need to create resources inside this module
-  create = "${var.create}"
+  create = var.create
 
-  ecs_container_name = "${var.container_name}"
+  ecs_container_name = var.container_name
 
   # Terraform state task definition
-  aws_ecs_task_definition_family   = "${module.ecs_task_definition.aws_ecs_task_definition_family}"
-  aws_ecs_task_definition_revision = "${module.ecs_task_definition.aws_ecs_task_definition_revision}"
+  aws_ecs_task_definition_family   = module.ecs_task_definition.aws_ecs_task_definition_family
+  aws_ecs_task_definition_revision = module.ecs_task_definition.aws_ecs_task_definition_revision
 
   # Live ecs task definition
-  live_aws_ecs_task_definition_revision           = "${module.live_task_lookup.revision}"
-  live_aws_ecs_task_definition_image              = "${module.live_task_lookup.image}"
-  live_aws_ecs_task_definition_cpu                = "${module.live_task_lookup.cpu}"
-  live_aws_ecs_task_definition_memory             = "${module.live_task_lookup.memory}"
-  live_aws_ecs_task_definition_memory_reservation = "${module.live_task_lookup.memory_reservation}"
-  live_aws_ecs_task_definition_environment_json   = "${module.live_task_lookup.environment_json}"
-  live_aws_ecs_task_definition_docker_label_hash  = "${module.live_task_lookup.docker_label_hash}"
-  live_aws_ecs_task_definition_secrets_hash       = "${module.live_task_lookup.secrets_hash}"
+  live_aws_ecs_task_definition_revision           = module.live_task_lookup.revision
+  live_aws_ecs_task_definition_image              = module.live_task_lookup.image
+  live_aws_ecs_task_definition_cpu                = module.live_task_lookup.cpu
+  live_aws_ecs_task_definition_memory             = module.live_task_lookup.memory
+  live_aws_ecs_task_definition_memory_reservation = module.live_task_lookup.memory_reservation
+  live_aws_ecs_task_definition_environment_json   = module.live_task_lookup.environment_json
+  live_aws_ecs_task_definition_docker_label_hash  = module.live_task_lookup.docker_label_hash
+  live_aws_ecs_task_definition_secrets_hash       = module.live_task_lookup.secrets_hash
 }
 
 #
@@ -297,83 +300,83 @@ module "ecs_task_definition_selector" {
 module "ecs_service" {
   source = "./modules/ecs_service/"
 
-  name = "${var.name}"
+  name = var.name
 
   # create defines if resources are being created inside this module
-  create = "${var.create && !var.is_scheduled_task}"
+  create = var.create && false == var.is_scheduled_task
 
-  cluster_id = "${var.ecs_cluster_id}"
+  cluster_id = var.ecs_cluster_id
 
-  awsvpc_enabled = "${var.awsvpc_enabled}"
+  awsvpc_enabled = var.awsvpc_enabled
 
   # launch_type either EC2 or FARGATE
-  launch_type = "${local.launch_type}"
+  launch_type = local.launch_type
 
-  selected_task_definition = "${module.ecs_task_definition_selector.selected_task_definition_for_deployment}"
+  selected_task_definition = module.ecs_task_definition_selector.selected_task_definition_for_deployment
 
   # deployment_controller_type sets the deployment type
   # ECS for Rolling update, and CODE_DEPLOY for Blue/Green deployment via CodeDeploy
-  deployment_controller_type = "${var.deployment_controller_type}"
+  deployment_controller_type = var.deployment_controller_type
 
   # deployment_maximum_percent sets the maximum size of the deployment in % of the normal size.
-  deployment_maximum_percent = "${var.capacity_properties_deployment_maximum_percent}"
+  deployment_maximum_percent = var.capacity_properties_deployment_maximum_percent
 
   # deployment_minimum_healthy_percent sets the minimum % in capacity at deployment
-  deployment_minimum_healthy_percent = "${var.capacity_properties_deployment_minimum_healthy_percent}"
+  deployment_minimum_healthy_percent = var.capacity_properties_deployment_minimum_healthy_percent
 
-  health_check_grace_period_seconds = "${var.health_check_grace_period_seconds}"
+  health_check_grace_period_seconds = var.health_check_grace_period_seconds
 
   # load_balancing_type sets the type, either "none", "application", or "network"
-  load_balancing_type = "${var.load_balancing_type}"
+  load_balancing_type = var.load_balancing_type
 
   # awsvpc_subnets defines the subnets for an awsvpc ecs module
-  awsvpc_subnets = "${var.awsvpc_subnets}"
+  awsvpc_subnets = var.awsvpc_subnets
 
   # awsvpc_security_group_ids defines the vpc_security_group_ids for an awsvpc module
-  awsvpc_security_group_ids = "${var.awsvpc_security_group_ids}"
+  awsvpc_security_group_ids = var.awsvpc_security_group_ids
 
   # lb_target_group_arn sets the arn of the target_group the service needs to connect to
-  lb_target_group_arn = "${module.alb_handling.lb_target_group_arn}"
+  lb_target_group_arn = module.alb_handling.lb_target_group_arn
 
   # desired_capacity sets the initial capacity in task of the ECS Service, ignored when scheduling_strategy is DAEMON
-  desired_capacity = "${var.capacity_properties_desired_capacity}"
+  desired_capacity = var.capacity_properties_desired_capacity
 
   # scheduling_strategy
-  scheduling_strategy = "${var.scheduling_strategy}"
+  scheduling_strategy = var.scheduling_strategy
 
   # with_placement_strategy, if true spread tasks over ECS Cluster based on AZ, Instance-id, Memory
-  with_placement_strategy = "${var.with_placement_strategy}"
+  with_placement_strategy = var.with_placement_strategy
 
   # container_name sets the name of the container, this is used for the load balancer section inside the ecs_service to connect to a container_name defined inside the 
   # task definition, container_port sets the port for the same container.
-  container_name = "${var.container_name}"
+  container_name = var.container_name
 
-  container_port = "${var.container_port}"
+  container_port = var.container_port
 
   # This way we force the aws_lb_listener_rule to have finished before creating the ecs_service
-  aws_lb_listener_rules = "${module.alb_handling.aws_lb_listener_rules}"
+  aws_lb_listener_rules = module.alb_handling.aws_lb_listener_rules
 
   # https://aws.amazon.com/blogs/aws/amazon-ecs-service-discovery/
   # service_discovery_enabled defaults to false
-  service_discovery_enabled = "${var.service_discovery_enabled}"
+  service_discovery_enabled = var.service_discovery_enabled
 
   # Should error when service_discovery_enabled is set and no namespace_id is given
-  service_discovery_namespace_id = "${var.service_discovery_properties_namespace_id}"
+  service_discovery_namespace_id = var.service_discovery_properties_namespace_id
 
   # ttl of the service discovery records, default 60
-  service_discovery_dns_ttl = "${var.service_discovery_properties_dns_ttl}"
+  service_discovery_dns_ttl = var.service_discovery_properties_dns_ttl
 
   # dns_type defaults to A (AWSVPC)
-  service_discovery_dns_type = "${var.service_discovery_properties_dns_type}"
+  service_discovery_dns_type = var.service_discovery_properties_dns_type
 
   # service_discovery_properties_routing_policy
-  service_discovery_routing_policy = "${var.service_discovery_properties_routing_policy}"
+  service_discovery_routing_policy = var.service_discovery_properties_routing_policy
 
   # healthcheck_custom_failure_threshold needed, set to 1 by default
-  service_discovery_healthcheck_custom_failure_threshold = "${var.service_discovery_properties_healthcheck_custom_failure_threshold}"
+  service_discovery_healthcheck_custom_failure_threshold = var.service_discovery_properties_healthcheck_custom_failure_threshold
 
   # tags
-  tags = "${local.tags}"
+  tags = local.tags
 }
 
 #
@@ -383,21 +386,21 @@ module "ecs_autoscaling" {
   source = "./modules/ecs_autoscaling/"
 
   # create defines if resources inside this module are being created.
-  create = "${var.create && !var.is_scheduled_task && length(var.scaling_properties) > 0 ? true : false }"
+  create = var.create && false == var.is_scheduled_task && length(var.scaling_properties) > 0 ? true : false
 
-  cluster_name = "${local.ecs_cluster_name}"
+  cluster_name = local.ecs_cluster_name
 
   # ecs_service_name is derived from the actual ecs_service, this to force dependency at creation.
-  ecs_service_name = "${module.ecs_service.ecs_service_name}"
+  ecs_service_name = module.ecs_service.ecs_service_name
 
   # desired_min_capacity, in case of autoscaling, desired_min_capacity sets the minimum size in tasks
-  desired_min_capacity = "${var.capacity_properties_desired_min_capacity}"
+  desired_min_capacity = var.capacity_properties_desired_min_capacity
 
   # desired_max_capaity, in case of autoscaling, desired_max_capacity sets the maximum size in tasks
-  desired_max_capacity = "${var.capacity_properties_desired_max_capacity}"
+  desired_max_capacity = var.capacity_properties_desired_max_capacity
 
   # scaling_properties holds a list of maps with the scaling properties defined.
-  scaling_properties = "${var.scaling_properties}"
+  scaling_properties = var.scaling_properties
 }
 
 # This modules creates scheduled tasks for the ecs service. This is not the same as ECS scheduled tasks! 
@@ -406,53 +409,55 @@ module "lambda_ecs_task_scheduler" {
   source = "./modules/lambda_ecs_task_scheduler/"
 
   # create defines if resources inside this module are being created.
-  create = "${var.create && !var.is_scheduled_task && length(var.ecs_cron_tasks) > 0 ? true : false }"
+  create = var.create && false == var.is_scheduled_task && length(var.ecs_cron_tasks) > 0 ? true : false
 
-  ecs_cluster_id = "${var.ecs_cluster_id}"
+  ecs_cluster_id = var.ecs_cluster_id
 
-  container_name = "${var.container_name}"
+  container_name = var.container_name
 
   # ecs_service_name is derived from the actual ecs_service, this to force dependency at creation.
-  ecs_service_name = "${module.ecs_service.ecs_service_name}"
+  ecs_service_name = module.ecs_service.ecs_service_name
 
   # var.ecs_scheduled_tasks holds a list with maps regarding the scheduled tasks
-  ecs_cron_tasks = "${var.ecs_cron_tasks}"
+  ecs_cron_tasks = var.ecs_cron_tasks
 
   # lambda_ecs_task_scheduler_role_arn sets the role arn of the task scheduling lambda
-  lambda_ecs_task_scheduler_role_arn = "${module.iam.lambda_ecs_task_scheduler_role_arn}"
+  lambda_ecs_task_scheduler_role_arn = module.iam.lambda_ecs_task_scheduler_role_arn
 
-  lambda_runtime = "${var.lambda_ecs_task_scheduler_runtime}"
+  lambda_runtime = var.lambda_ecs_task_scheduler_runtime
 }
 
 # ECS scheduled task configuration. This uses a CloudWatch rulle to start an ECS task at given intervals.
 data "aws_ecs_cluster" "this" {
-  cluster_name = "${var.ecs_cluster_id}"
+  cluster_name = var.ecs_cluster_id
 }
 
 resource "aws_cloudwatch_event_rule" "scheduled_task" {
-  count               = "${var.is_scheduled_task ? 1 : 0}"
+  count               = var.is_scheduled_task ? 1 : 0
   name                = "${length(var.scheduled_task_name) == 0 ? var.name : var.scheduled_task_name}_scheduled_task"
   description         = "Run ${var.name} task at a scheduled time (${var.scheduled_task_expression})"
-  schedule_expression = "${var.scheduled_task_expression}"
+  schedule_expression = var.scheduled_task_expression
 }
 
-data "aws_caller_identity" "current" {}
+data "aws_caller_identity" "current" {
+}
 
 resource "aws_cloudwatch_event_target" "scheduled_task" {
-  count    = "${var.is_scheduled_task ? 1 : 0}"
-  rule     = "${aws_cloudwatch_event_rule.scheduled_task.name}"
-  arn      = "${data.aws_ecs_cluster.this.arn}"
-  role_arn = "${module.iam.scheduled_task_cloudwatch_role_arn}"
+  count    = var.is_scheduled_task ? 1 : 0
+  rule     = aws_cloudwatch_event_rule.scheduled_task[0].name
+  arn      = data.aws_ecs_cluster.this.arn
+  role_arn = module.iam.scheduled_task_cloudwatch_role_arn
 
   ecs_target {
-    group               = "${var.scheduled_task_group}"
-    launch_type         = "${local.launch_type}"
-    task_count          = "${var.scheduled_task_count}"
+    group               = var.scheduled_task_group
+    launch_type         = local.launch_type
+    task_count          = var.scheduled_task_count
     task_definition_arn = "arn:aws:ecs:${var.region}:${data.aws_caller_identity.current.account_id}:task-definition/${module.ecs_task_definition_selector.selected_task_definition_for_deployment}"
 
-    network_configuration = {
-      subnets         = ["${var.awsvpc_subnets}"]
-      security_groups = ["${var.awsvpc_security_group_ids}"]
+    network_configuration {
+      subnets         = var.awsvpc_subnets
+      security_groups = var.awsvpc_security_group_ids
     }
   }
 }
+

--- a/main.tf
+++ b/main.tf
@@ -303,7 +303,7 @@ module "ecs_service" {
   name = var.name
 
   # create defines if resources are being created inside this module
-  create = var.create && false == var.is_scheduled_task
+  create = var.create && !var.is_scheduled_task
 
   cluster_id = var.ecs_cluster_id
 

--- a/main.tf
+++ b/main.tf
@@ -192,7 +192,7 @@ module "live_task_lookup" {
 module "container_definition" {
   source            = "./modules/ecs_container_definition/"
   container_name    = var.container_name
-  container_command = [var.container_command]
+  container_command = var.container_command
 
   # if var.force_bootstrap_container_image is enabled, we always take the terraform param as container_image
   # otherwise we take the image from the datasource lookup

--- a/modules/alb_handling/main.tf
+++ b/modules/alb_handling/main.tf
@@ -1,40 +1,40 @@
 data "aws_lb" "main" {
-  count = "${var.create && var.route53_record_type != "NONE" ? 1 : 0}"
-  arn   = "${var.lb_arn}"
+  count = var.create && var.route53_record_type != "NONE" ? 1 : 0
+  arn   = var.lb_arn
 }
 
 locals {
   # Validate the load_balancing_type type by looking up the map with var.allowed_load_balancing_types
-  validate_load_balancing_type = "${lookup(var.allowed_load_balancing_types,var.load_balancing_type)}"
+  validate_load_balancing_type = var.allowed_load_balancing_types[var.load_balancing_type]
 
   # Validate the record type by looking up the map with valid record types
-  route53_record_type = "${lookup(var.allowed_record_types,var.route53_record_type)}"
+  route53_record_type = var.allowed_record_types[var.route53_record_type]
 
   # We limit the target group name to a length of 32
-  tg_name = "${format("%.32s",format("%v-%v", var.cluster_name, var.name))}"
+  tg_name = format("%.32s", format("%v-%v", var.cluster_name, var.name))
 }
 
 ## Route53 DNS Record
 resource "aws_route53_record" "record" {
-  count = "${(var.create && var.route53_record_type == "CNAME" ) ? 1 : 0 }"
+  count = var.create && var.route53_record_type == "CNAME" ? 1 : 0
 
-  zone_id = "${var.route53_zone_id}"
-  name    = "${var.route53_name}"
+  zone_id = var.route53_zone_id
+  name    = var.route53_name
   type    = "CNAME"
   ttl     = "300"
-  records = ["${data.aws_lb.main.dns_name}"]
+  records = [data.aws_lb.main[0].dns_name]
 }
 
 ## Route53 DNS Record
 resource "aws_route53_record" "record_alias_a" {
-  count   = "${(var.create && var.route53_record_type == "ALIAS") ? 1 : 0 }"
-  zone_id = "${var.route53_zone_id}"
-  name    = "${var.route53_name}"
+  count   = var.create && var.route53_record_type == "ALIAS" ? 1 : 0
+  zone_id = var.route53_zone_id
+  name    = var.route53_name
   type    = "A"
 
   alias {
-    name                   = "${data.aws_lb.main.dns_name}"
-    zone_id                = "${data.aws_lb.main.zone_id}"
+    name                   = data.aws_lb.main[0].dns_name
+    zone_id                = data.aws_lb.main[0].zone_id
     evaluate_target_health = false
   }
 
@@ -44,38 +44,38 @@ resource "aws_route53_record" "record_alias_a" {
     weight = 0
   }
 
-  set_identifier = "${var.route53_record_identifier}"
+  set_identifier = var.route53_record_identifier
 }
 
 # Network service load_balancer_type
 resource "aws_lb_target_group" "service_nlb" {
-  count                = "${var.create && var.load_balancing_type == "network" ? 1 : 0 }"
-  name                 = "${local.tg_name}"
-  port                 = "${var.target_group_port}"
+  count                = var.create && var.load_balancing_type == "network" ? 1 : 0
+  name                 = local.tg_name
+  port                 = var.target_group_port
   protocol             = "TCP"
-  vpc_id               = "${var.lb_vpc_id}"
-  target_type          = "${var.target_type}"
-  deregistration_delay = "${var.deregistration_delay}"
+  vpc_id               = var.lb_vpc_id
+  target_type          = var.target_type
+  deregistration_delay = var.deregistration_delay
 
   health_check {
     protocol = "TCP"
 
     ## health_check.healthy_threshold 3 and health_check.unhealthy_threshold 0 must be the same for target_groups with TCP protocol
-    healthy_threshold   = "${max(var.healthy_threshold,var.unhealthy_threshold)}"
-    unhealthy_threshold = "${max(var.healthy_threshold,var.unhealthy_threshold)}"
+    healthy_threshold   = max(var.healthy_threshold, var.unhealthy_threshold)
+    unhealthy_threshold = max(var.healthy_threshold, var.unhealthy_threshold)
   }
 
-  tags = "${local.tags}"
+  tags = local.tags
 }
 
 resource "aws_lb_listener" "nlb_listener" {
-  count             = "${var.create && var.load_balancing_type == "network" ? 1 : 0 }"
-  load_balancer_arn = "${var.lb_arn}"
-  port              = "${var.nlb_listener_port}"
+  count             = var.create && var.load_balancing_type == "network" ? 1 : 0
+  load_balancer_arn = var.lb_arn
+  port              = var.nlb_listener_port
   protocol          = "TCP"
 
   default_action {
-    target_group_arn = "${aws_lb_target_group.service_nlb.arn}"
+    target_group_arn = aws_lb_target_group.service_nlb[0].arn
     type             = "forward"
   }
 }
@@ -84,51 +84,51 @@ resource "aws_lb_listener" "nlb_listener" {
 ## aws_lb_target_group inside the ECS Task will be created when the service is not the default forwarding service
 ## It will not be created when the service is not attached to a load balancer like a worker
 resource "aws_lb_target_group" "service" {
-  count                = "${var.create && var.load_balancing_type == "application" ? 1 : 0 }"
-  name                 = "${local.tg_name}"
-  port                 = "${var.target_group_port}"
+  count                = var.create && var.load_balancing_type == "application" ? 1 : 0
+  name                 = local.tg_name
+  port                 = var.target_group_port
   protocol             = "HTTP"
-  vpc_id               = "${var.lb_vpc_id}"
-  target_type          = "${var.target_type}"
-  deregistration_delay = "${var.deregistration_delay}"
+  vpc_id               = var.lb_vpc_id
+  target_type          = var.target_type
+  deregistration_delay = var.deregistration_delay
 
   health_check {
-    matcher             = "${var.health_matcher}"
-    path                = "${var.health_uri}"
-    unhealthy_threshold = "${var.unhealthy_threshold}"
-    healthy_threshold   = "${var.healthy_threshold}"
-    port                = "${var.health_port}"
+    matcher             = var.health_matcher
+    path                = var.health_uri
+    unhealthy_threshold = var.unhealthy_threshold
+    healthy_threshold   = var.healthy_threshold
+    port                = var.health_port
   }
 }
 
 ##
 ## An aws_lb_listener_rule will only be created when a service has a load balancer attached
 resource "aws_lb_listener_rule" "host_based_routing" {
-  count = "${var.create && var.load_balancing_type == "application" && ! var.redirect_http_to_https && local.route53_record_type != "NONE" ? 1 : 0 }"
+  count = var.create && var.load_balancing_type == "application" && false == var.redirect_http_to_https && local.route53_record_type != "NONE" ? 1 : 0
 
-  listener_arn = "${var.lb_listener_arn}"
+  listener_arn = var.lb_listener_arn
 
   action {
     type             = "forward"
-    target_group_arn = "${aws_lb_target_group.service.arn}"
+    target_group_arn = aws_lb_target_group.service[0].arn
   }
 
   condition {
     host_header {
-      values = ["${local.route53_record_type == "CNAME" ? 
-       join("",aws_route53_record.record.*.fqdn)
-       :
-       join("",aws_route53_record.record_alias_a.*.fqdn)
-       }"]
+      values = [local.route53_record_type == "CNAME" ? 
+        join("",aws_route53_record.record.*.fqdn)
+        :
+        join("",aws_route53_record.record_alias_a.*.fqdn)
+      ]
     }
   }
 }
 
 ## aws_lb_listener_rule which redirects http to https
 resource "aws_lb_listener_rule" "host_based_routing_redirect_to_https" {
-  count = "${var.create && var.load_balancing_type == "application" && var.redirect_http_to_https && local.route53_record_type != "NONE" ? 1 : 0 }"
+  count = var.create && var.load_balancing_type == "application" && var.redirect_http_to_https && local.route53_record_type != "NONE" ? 1 : 0
 
-  listener_arn = "${var.lb_listener_arn}"
+  listener_arn = var.lb_listener_arn
 
   action {
     type = "redirect"
@@ -142,11 +142,11 @@ resource "aws_lb_listener_rule" "host_based_routing_redirect_to_https" {
 
   condition {
     host_header {
-      values = ["${local.route53_record_type == "CNAME" ?
-       join("",aws_route53_record.record.*.fqdn)
-       :
-       join("",aws_route53_record.record_alias_a.*.fqdn)
-       }"]
+      values = [local.route53_record_type == "CNAME" ?
+        join("",aws_route53_record.record.*.fqdn)
+        :
+        join("",aws_route53_record.record_alias_a.*.fqdn)
+      ]
     }
   }
 }
@@ -154,22 +154,22 @@ resource "aws_lb_listener_rule" "host_based_routing_redirect_to_https" {
 ##
 ## An aws_lb_listener_rule will only be created when a service has a load balancer attached
 resource "aws_lb_listener_rule" "host_based_routing_ssl" {
-  count = "${var.create && var.https_enabled && var.load_balancing_type == "application" && ! var.cognito_auth_enabled && local.route53_record_type != "NONE" ? 1 : 0 }"
+  count = var.create && var.https_enabled && var.load_balancing_type == "application" && false == var.cognito_auth_enabled && local.route53_record_type != "NONE" ? 1 : 0
 
-  listener_arn = "${var.lb_listener_arn_https}"
+  listener_arn = var.lb_listener_arn_https
 
   action {
     type             = "forward"
-    target_group_arn = "${aws_lb_target_group.service.arn}"
+    target_group_arn = aws_lb_target_group.service[0].arn
   }
 
   condition {
     host_header {
-      values = ["${local.route53_record_type == "CNAME" ?
-       join("",aws_route53_record.record.*.fqdn)
-       :
-       join("",aws_route53_record.record_alias_a.*.fqdn)
-       }"]
+      values = [local.route53_record_type == "CNAME" ?
+        join("",aws_route53_record.record.*.fqdn)
+        :
+        join("",aws_route53_record.record_alias_a.*.fqdn)
+      ]
     }
   }
 }
@@ -177,61 +177,61 @@ resource "aws_lb_listener_rule" "host_based_routing_ssl" {
 ##
 ## An aws_lb_listener_rule will only be created when a service has a load balancer attached
 resource "aws_lb_listener_rule" "host_based_routing_ssl_cognito_auth" {
-  count = "${var.create && var.https_enabled && var.load_balancing_type == "application" && var.cognito_auth_enabled && local.route53_record_type != "NONE" ? 1 : 0 }"
+  count = var.create && var.https_enabled && var.load_balancing_type == "application" && var.cognito_auth_enabled && local.route53_record_type != "NONE" ? 1 : 0
 
-  listener_arn = "${var.lb_listener_arn_https}"
+  listener_arn = var.lb_listener_arn_https
 
   action {
     type = "authenticate-cognito"
 
     authenticate_cognito {
-      user_pool_arn       = "${var.cognito_user_pool_arn}"
-      user_pool_client_id = "${var.cognito_user_pool_client_id}"
-      user_pool_domain    = "${var.cognito_user_pool_domain}"
+      user_pool_arn       = var.cognito_user_pool_arn
+      user_pool_client_id = var.cognito_user_pool_client_id
+      user_pool_domain    = var.cognito_user_pool_domain
     }
   }
 
   action {
     type             = "forward"
-    target_group_arn = "${aws_lb_target_group.service.arn}"
+    target_group_arn = aws_lb_target_group.service[0].arn
   }
 
   condition {
     host_header {
-      values = ["${local.route53_record_type == "CNAME" ?
-       join("",aws_route53_record.record.*.fqdn)
-       :
-       join("",aws_route53_record.record_alias_a.*.fqdn)
-       }"]
+      values = [local.route53_record_type == "CNAME" ?
+        join("",aws_route53_record.record.*.fqdn)
+        :
+        join("",aws_route53_record.record_alias_a.*.fqdn)
+      ]
     }
   }
 }
 
 data "template_file" "custom_listen_host" {
-  count = "${var.custom_listen_hosts_count}"
+  count = var.custom_listen_hosts_count
 
   template = "$${listen_host}"
 
-  vars {
-    listen_host = "${var.custom_listen_hosts[count.index]}"
+  vars = {
+    listen_host = var.custom_listen_hosts[count.index]
   }
 }
 
 ##
 ## An aws_lb_listener_rule will only be created when a service has a load balancer attached
 resource "aws_lb_listener_rule" "host_based_routing_custom_listen_host" {
-  count = "${var.create && var.load_balancing_type == "application" && ! var.redirect_http_to_https ? var.custom_listen_hosts_count : 0 }"
+  count = var.create && var.load_balancing_type == "application" && false == var.redirect_http_to_https ? var.custom_listen_hosts_count : 0
 
-  listener_arn = "${var.lb_listener_arn}"
+  listener_arn = var.lb_listener_arn
 
   action {
     type             = "forward"
-    target_group_arn = "${aws_lb_target_group.service.arn}"
+    target_group_arn = aws_lb_target_group.service[0].arn
   }
 
   condition {
     host_header {
-      values = ["${data.template_file.custom_listen_host.*.rendered[count.index]}"]
+      values = [data.template_file.custom_listen_host.*.rendered[count.index]]
     }
   }
 }
@@ -239,9 +239,9 @@ resource "aws_lb_listener_rule" "host_based_routing_custom_listen_host" {
 ##
 ## aws_lb_listener_rule which redirects http to https for the custom listen hosts
 resource "aws_lb_listener_rule" "host_based_routing_custom_listen_host_redirect_to_https" {
-  count = "${var.create && var.load_balancing_type == "application" && !var.cognito_auth_enabled && var.redirect_http_to_https ? var.custom_listen_hosts_count : 0 }"
+  count = var.create && var.load_balancing_type == "application" && false == var.cognito_auth_enabled && var.redirect_http_to_https ? var.custom_listen_hosts_count : 0
 
-  listener_arn = "${var.lb_listener_arn}"
+  listener_arn = var.lb_listener_arn
 
   action {
     type = "redirect"
@@ -255,7 +255,7 @@ resource "aws_lb_listener_rule" "host_based_routing_custom_listen_host_redirect_
 
   condition {
     host_header {
-      values = ["${data.template_file.custom_listen_host.*.rendered[count.index]}"]
+      values = [data.template_file.custom_listen_host.*.rendered[count.index]]
     }
   }
 }
@@ -263,18 +263,18 @@ resource "aws_lb_listener_rule" "host_based_routing_custom_listen_host_redirect_
 ##
 ## An aws_lb_listener_rule will only be created when a service has a load balancer attached
 resource "aws_lb_listener_rule" "host_based_routing_ssl_custom_listen_host" {
-  count = "${var.create && var.https_enabled && var.load_balancing_type == "application" && !var.cognito_auth_enabled ? var.custom_listen_hosts_count : 0 }"
+  count = var.create && var.https_enabled && var.load_balancing_type == "application" && false == var.cognito_auth_enabled ? var.custom_listen_hosts_count : 0
 
-  listener_arn = "${var.lb_listener_arn_https}"
+  listener_arn = var.lb_listener_arn_https
 
   action {
     type             = "forward"
-    target_group_arn = "${aws_lb_target_group.service.arn}"
+    target_group_arn = aws_lb_target_group.service[0].arn
   }
 
   condition {
     host_header {
-      values = ["${data.template_file.custom_listen_host.*.rendered[count.index]}"]
+      values = [data.template_file.custom_listen_host.*.rendered[count.index]]
     }
   }
 }
@@ -283,27 +283,28 @@ resource "aws_lb_listener_rule" "host_based_routing_ssl_custom_listen_host" {
 ## An aws_lb_listener_rule will only be created when a service has a load balancer attached
 resource "aws_lb_listener_rule" "host_based_routing_ssl_custom_listen_host_cognito_auth" {
   # count = "${var.create && var.load_balancing_type == "application" && var.cognito_auth_enabled ? var.custom_listen_hosts_count : 0 }"
-  count        = "${var.create && var.https_enabled && var.load_balancing_type == "application" && var.cognito_auth_enabled ? var.custom_listen_hosts_count : 0}"
-  listener_arn = "${var.lb_listener_arn_https}"
+  count        = var.create && var.https_enabled && var.load_balancing_type == "application" && var.cognito_auth_enabled ? var.custom_listen_hosts_count : 0
+  listener_arn = var.lb_listener_arn_https
 
   action {
     type = "authenticate-cognito"
 
     authenticate_cognito {
-      user_pool_arn       = "${var.cognito_user_pool_arn}"
-      user_pool_client_id = "${var.cognito_user_pool_client_id}"
-      user_pool_domain    = "${var.cognito_user_pool_domain}"
+      user_pool_arn       = var.cognito_user_pool_arn
+      user_pool_client_id = var.cognito_user_pool_client_id
+      user_pool_domain    = var.cognito_user_pool_domain
     }
   }
 
   action {
     type             = "forward"
-    target_group_arn = "${aws_lb_target_group.service.arn}"
+    target_group_arn = aws_lb_target_group.service[0].arn
   }
 
   condition {
     host_header {
-      values = ["${data.template_file.custom_listen_host.*.rendered[count.index]}"]
+      values = [data.template_file.custom_listen_host.*.rendered[count.index]]
     }
   }
 }
+

--- a/modules/alb_handling/main.tf
+++ b/modules/alb_handling/main.tf
@@ -104,7 +104,7 @@ resource "aws_lb_target_group" "service" {
 ##
 ## An aws_lb_listener_rule will only be created when a service has a load balancer attached
 resource "aws_lb_listener_rule" "host_based_routing" {
-  count = var.create && var.load_balancing_type == "application" && false == var.redirect_http_to_https && local.route53_record_type != "NONE" ? 1 : 0
+  count = var.create && var.http_enabled && var.load_balancing_type == "application" && false == var.redirect_http_to_https && local.route53_record_type != "NONE" ? 1 : 0
 
   listener_arn = var.lb_listener_arn
 
@@ -126,7 +126,7 @@ resource "aws_lb_listener_rule" "host_based_routing" {
 
 ## aws_lb_listener_rule which redirects http to https
 resource "aws_lb_listener_rule" "host_based_routing_redirect_to_https" {
-  count = var.create && var.load_balancing_type == "application" && var.redirect_http_to_https && local.route53_record_type != "NONE" ? 1 : 0
+  count = var.create && var.http_enabled && var.load_balancing_type == "application" && var.redirect_http_to_https && local.route53_record_type != "NONE" ? 1 : 0
 
   listener_arn = var.lb_listener_arn
 

--- a/modules/alb_handling/output.tf
+++ b/modules/alb_handling/output.tf
@@ -1,8 +1,21 @@
 output "lb_target_group_arn" {
-  value = "${element(concat(aws_lb_target_group.service.*.arn,aws_lb_target_group.service_nlb.*.arn, list("")), 0)}"
+  value = element(
+    concat(
+      aws_lb_target_group.service.*.arn,
+      aws_lb_target_group.service_nlb.*.arn,
+      [""],
+    ),
+    0,
+  )
 }
 
 # This is an output the ecs_service depends on. This to make sure the target_group is attached to an alb before adding to a service. The actual content is useless
 output "aws_lb_listener_rules" {
-  value = ["${concat(aws_lb_listener_rule.host_based_routing.*.arn,aws_lb_listener_rule.host_based_routing_custom_listen_host.*.arn, aws_lb_listener_rule.host_based_routing_ssl_custom_listen_host_cognito_auth.*.arn, list())}"]
+  value = concat(
+    aws_lb_listener_rule.host_based_routing.*.arn,
+    aws_lb_listener_rule.host_based_routing_custom_listen_host.*.arn,
+    aws_lb_listener_rule.host_based_routing_ssl_custom_listen_host_cognito_auth.*.arn,
+    [],
+  )
 }
+

--- a/modules/alb_handling/variables.tf
+++ b/modules/alb_handling/variables.tf
@@ -131,6 +131,11 @@ variable "custom_listen_hosts_count" {
   default = "0"
 }
 
+# When http is enabled we create http listener_rules
+variable "http_enabled" {
+  default = true
+}
+
 # When https is enabled we create https listener_rules
 variable "https_enabled" {
   default = true

--- a/modules/alb_handling/variables.tf
+++ b/modules/alb_handling/variables.tf
@@ -7,16 +7,19 @@ variable "create" {
 
 # What kind of load balancing, "none", "application", "network"
 variable "load_balancing_type" {
-  type = "string"
+  type = string
 }
 
 # The amount time for Elastic Load Balancing to wait before changing the state of a deregistering target from draining to unused. The range is 0-3600 seconds. 
-variable "deregistration_delay" {}
+variable "deregistration_delay" {
+}
 
 # unhealthy_threshold defines the threashold for the target_group after which a service is seen as unhealthy.
-variable "unhealthy_threshold" {}
+variable "unhealthy_threshold" {
+}
 
-variable "healthy_threshold" {}
+variable "healthy_threshold" {
+}
 
 variable "cluster_name" {
   default = ""
@@ -115,11 +118,12 @@ variable "allowed_record_types" {
 }
 
 # route53_record_type, one of the allowed values of the map allowed_record_types
-variable "route53_record_type" {}
+variable "route53_record_type" {
+}
 
 # the custom_listen_hosts will be added as a host route rule as aws_lb_listener_rule to the given service e.g. www.domain.com -> Service
 variable "custom_listen_hosts" {
-  type    = "list"
+  type    = list(string)
   default = []
 }
 
@@ -133,7 +137,8 @@ variable "https_enabled" {
 }
 
 # route53_record_identifier, sets the identifier for the route53 record in case the record type is ALIAS 
-variable "route53_record_identifier" {}
+variable "route53_record_identifier" {
+}
 
 # cognito_auth_enabled is set when cognito authentication is used for the https listener
 variable "cognito_auth_enabled" {
@@ -157,14 +162,15 @@ variable "cognito_user_pool_domain" {
 
 variable "tags" {
   description = "A map of tags to apply to all resources"
-  type        = "map"
+  type        = map(string)
   default     = {}
 }
 
 locals {
   name_map = {
-    "Name" = "${var.name}"
+    "Name" = var.name
   }
 
-  tags = "${merge(var.tags, local.name_map)}"
+  tags = merge(var.tags, local.name_map)
 }
+

--- a/modules/ecs_autoscaling/main.tf
+++ b/modules/ecs_autoscaling/main.tf
@@ -3,57 +3,67 @@ locals {
 }
 
 resource "aws_appautoscaling_target" "target" {
-  count              = "${var.create ? 1 : 0 }"
+  count              = var.create ? 1 : 0
   service_namespace  = "ecs"
   resource_id        = "service/${var.cluster_name}/${var.ecs_service_name}"
   scalable_dimension = "ecs:service:DesiredCount"
-  min_capacity       = "${var.desired_min_capacity}"
-  max_capacity       = "${var.desired_max_capacity}"
+  min_capacity       = var.desired_min_capacity
+  max_capacity       = var.desired_max_capacity
 }
 
 resource "aws_appautoscaling_policy" "policy" {
-  count = "${(var.create ? 1 : 0 ) * length(var.scaling_properties) }"
+  count = var.create ? 1 : 0 * length(var.scaling_properties)
 
-  name               = "${local.cluster_plus_service_name}-${lookup(var.scaling_properties[count.index], "type")}-${element(var.direction[lookup(var.scaling_properties[count.index], "direction")],1)}"
+  name = "${local.cluster_plus_service_name}-${var.scaling_properties[count.index]["type"]}-${element(
+    var.direction[var.scaling_properties[count.index]["direction"]],
+    1,
+  )}"
   scalable_dimension = "ecs:service:DesiredCount"
   service_namespace  = "ecs"
   resource_id        = "service/${var.cluster_name}/${var.ecs_service_name}"
 
   step_scaling_policy_configuration {
-    adjustment_type         = "${lookup(var.scaling_properties[count.index], "adjustment_type")}"
-    cooldown                = "${lookup(var.scaling_properties[count.index], "cooldown")}"
+    adjustment_type         = var.scaling_properties[count.index]["adjustment_type"]
+    cooldown                = var.scaling_properties[count.index]["cooldown"]
     metric_aggregation_type = "Average"
 
     step_adjustment {
-      metric_interval_lower_bound = "${lookup(var.scaling_properties[count.index], "scaling_adjustment") == "-1" ? "" : "0"}"
-      metric_interval_upper_bound = "${lookup(var.scaling_properties[count.index], "scaling_adjustment") == "-1" ? "0" : ""}"
-      scaling_adjustment          = "${lookup(var.scaling_properties[count.index], "scaling_adjustment")}"
+      metric_interval_lower_bound = var.scaling_properties[count.index]["scaling_adjustment"] == "-1" ? "" : "0"
+      metric_interval_upper_bound = var.scaling_properties[count.index]["scaling_adjustment"] == "-1" ? "0" : ""
+      scaling_adjustment          = var.scaling_properties[count.index]["scaling_adjustment"]
     }
   }
 
-  depends_on = ["aws_appautoscaling_target.target"]
+  depends_on = [aws_appautoscaling_target.target]
 }
 
 resource "aws_cloudwatch_metric_alarm" "alarm" {
-  count = "${(var.create ? 1 : 0 ) * length(var.scaling_properties) }"
+  count = var.create ? 1 : 0 * length(var.scaling_properties)
 
-  alarm_name = "${local.cluster_plus_service_name}-${lookup(var.scaling_properties[count.index], "type")}-${element(var.direction[lookup(var.scaling_properties[count.index], "direction")],1)}"
+  alarm_name = "${local.cluster_plus_service_name}-${var.scaling_properties[count.index]["type"]}-${element(
+    var.direction[var.scaling_properties[count.index]["direction"]],
+    1,
+  )}"
 
-  comparison_operator = "${element(var.direction[lookup(var.scaling_properties[count.index], "direction")],0)}"
+  comparison_operator = element(
+    var.direction[var.scaling_properties[count.index]["direction"]],
+    0,
+  )
 
-  evaluation_periods = "${lookup(var.scaling_properties[count.index], "evaluation_periods")}"
-  metric_name        = "${lookup(var.scaling_properties[count.index], "type")}"
+  evaluation_periods = var.scaling_properties[count.index]["evaluation_periods"]
+  metric_name        = var.scaling_properties[count.index]["type"]
   namespace          = "AWS/ECS"
-  period             = "${lookup(var.scaling_properties[count.index], "observation_period")}"
-  statistic          = "${lookup(var.scaling_properties[count.index], "statistic")}"
-  threshold          = "${lookup(var.scaling_properties[count.index], "threshold")}"
+  period             = var.scaling_properties[count.index]["observation_period"]
+  statistic          = var.scaling_properties[count.index]["statistic"]
+  threshold          = var.scaling_properties[count.index]["threshold"]
 
-  dimensions {
-    ClusterName = "${var.cluster_name}"
-    ServiceName = "${var.ecs_service_name}"
+  dimensions = {
+    ClusterName = var.cluster_name
+    ServiceName = var.ecs_service_name
   }
 
-  alarm_actions = ["${aws_appautoscaling_policy.policy.*.arn[count.index]}"]
+  alarm_actions = [aws_appautoscaling_policy.policy[count.index].arn]
 
-  depends_on = ["aws_appautoscaling_target.target"]
+  depends_on = [aws_appautoscaling_target.target]
 }
+

--- a/modules/ecs_autoscaling/main.tf
+++ b/modules/ecs_autoscaling/main.tf
@@ -65,5 +65,6 @@ resource "aws_cloudwatch_metric_alarm" "alarm" {
   alarm_actions = [aws_appautoscaling_policy.policy[count.index].arn]
 
   depends_on = [aws_appautoscaling_target.target]
-}
 
+  tags = var.tags
+}

--- a/modules/ecs_autoscaling/variables.tf
+++ b/modules/ecs_autoscaling/variables.tf
@@ -1,6 +1,6 @@
 # Internal lookup map
 variable "direction" {
-  type = "map"
+  type = map(list(string))
 
   default = {
     up   = ["GreaterThanOrEqualToThreshold", "scale_out"]
@@ -9,21 +9,33 @@ variable "direction" {
 }
 
 # Sets the cluster_name 
-variable "cluster_name" {}
+variable "cluster_name" {
+  type = string
+}
 
 # Sets the ecs_service name
-variable "ecs_service_name" {}
+variable "ecs_service_name" {
+  type = string
+}
 
 # Do we create resources
-variable "create" {}
+variable "create" {
+  type = bool
+}
 
 # The minimum capacity in tasks for this service
-variable "desired_min_capacity" {}
+variable "desired_min_capacity" {
+  type = number
+}
 
 # The maximum capacity in tasks for this service
-variable "desired_max_capacity" {}
+variable "desired_max_capacity" {
+  type = number
+}
 
 # List of maps with scaling properties
 variable "scaling_properties" {
+  type    = list(map(string))
   default = []
 }
+

--- a/modules/ecs_autoscaling/variables.tf
+++ b/modules/ecs_autoscaling/variables.tf
@@ -39,3 +39,8 @@ variable "scaling_properties" {
   default = []
 }
 
+variable "tags" {
+  description = "A map of tags to apply to all taggable resources"
+  type        = map(string)
+  default     = {}
+}

--- a/modules/ecs_container_definition/main.tf
+++ b/modules/ecs_container_definition/main.tf
@@ -21,13 +21,13 @@ locals {
 
 
   port_mappings = {
-    with_port = [
+    with_port = concat([
       {
         containerPort = var.container_port
         hostPort      = var.host_port
         protocol      = var.protocol
-      },
-    ]
+      }],
+      var.extra_ports)
     without_port = []
   }
 

--- a/modules/ecs_container_definition/main.tf
+++ b/modules/ecs_container_definition/main.tf
@@ -9,92 +9,87 @@ locals {
 }
 
 resource "null_resource" "envvars_as_list_of_maps" {
-  count = "${length(keys(var.container_envvars))}"
+  count = length(keys(var.container_envvars))
 
-  triggers = "${map(
-    "name", "${local.safe_search_replace_string}${element(keys(var.container_envvars), count.index)}",
-    "value", "${local.safe_search_replace_string}${element(values(var.container_envvars), count.index)}",
-  )}"
+  triggers = {
+    "name"  = "${local.safe_search_replace_string}${element(keys(var.container_envvars), count.index)}"
+    "value" = "${local.safe_search_replace_string}${element(values(var.container_envvars), count.index)}"
+  }
 }
 
 resource "null_resource" "secrets_as_list_of_maps" {
-  count = "${length(keys(var.container_secrets))}"
+  count = length(keys(var.container_secrets))
 
-  triggers = "${map(
-    "name", "${local.safe_search_replace_string}${element(keys(var.container_secrets), count.index)}",
-    "valueFrom", "${local.safe_search_replace_string}${element(values(var.container_secrets), count.index)}",
-  )}"
+  triggers = {
+    "name"      = "${local.safe_search_replace_string}${element(keys(var.container_secrets), count.index)}"
+    "valueFrom" = "${local.safe_search_replace_string}${element(values(var.container_secrets), count.index)}"
+  }
 }
 
 locals {
   port_mappings = {
     with_port = [
       {
-        containerPort = "${var.container_port}"
-        hostPort      = "${var.host_port}"
-        protocol      = "${var.protocol}"
+        containerPort = var.container_port
+        hostPort      = var.host_port
+        protocol      = var.protocol
       },
     ]
-
     without_port = []
   }
 
   ulimits = {
     with_ulimits = [
       {
-        softLimit = "${var.ulimit_soft_limit}"
-        hardLimit = "${var.ulimit_hard_limit}"
-        name      = "${var.ulimit_name}"
+        softLimit = var.ulimit_soft_limit
+        hardLimit = var.ulimit_hard_limit
+        name      = var.ulimit_name
       },
     ]
-
     without_ulimits = []
   }
 
   repository_credentials = {
     with_credentials = {
-      credentialsParameter = "${var.repository_credentials_secret_arn}"
+      credentialsParameter = var.repository_credentials_secret_arn
     }
-
     without_credentials = {}
   }
 
-  use_port        = "${var.container_port == "" ? "without_port" : "with_port" }"
-  use_credentials = "${var.repository_credentials_secret_arn == "" ? "without_credentials" : "with_credentials" }"
-  use_ulimits     = "${var.ulimit_soft_limit == "" && var.ulimit_hard_limit == "" ? "without_ulimits" : "with_ulimits" }"
+  use_port        = var.container_port == "" ? "without_port" : "with_port"
+  use_credentials = var.repository_credentials_secret_arn == "" ? "without_credentials" : "with_credentials"
+  use_ulimits     = var.ulimit_soft_limit == "" && var.ulimit_hard_limit == "" ? "without_ulimits" : "with_ulimits"
 
-  container_definitions = [{
-    name                   = "${var.container_name}"
-    image                  = "${var.container_image}"
-    memory                 = "${var.container_memory}"
-    memoryReservation      = "${var.container_memory_reservation}"
-    cpu                    = "${var.container_cpu}"
-    essential              = "${var.essential}"
-    entryPoint             = "${var.entrypoint}"
-    command                = "${var.container_command}"
-    workingDirectory       = "${var.working_directory}"
-    readonlyRootFilesystem = "${var.readonly_root_filesystem}"
-    dockerLabels           = "${local.docker_labels}"
-
-    privileged = "${var.privileged}"
-
-    hostname              = "${var.hostname}"
-    environment           = ["${null_resource.envvars_as_list_of_maps.*.triggers}"]
-    secrets               = ["${null_resource.secrets_as_list_of_maps.*.triggers}"]
-    mountPoints           = ["${var.mountpoints}"]
-    portMappings          = "${local.port_mappings[local.use_port]}"
-    healthCheck           = "${var.healthcheck}"
-    repositoryCredentials = "${local.repository_credentials[local.use_credentials]}"
-
-    linuxParameters = {
-      initProcessEnabled = "${var.container_init_process_enabled ? true : false }"
-    }
-
-    ulimits = "${local.ulimits[local.use_ulimits]}"
-
-    logConfiguration = {
-      logDriver = "${var.log_driver}"
-      options   = "${var.log_options}"
-    }
-  }]
+  container_definitions = [
+    {
+      name                   = var.container_name
+      image                  = var.container_image
+      memory                 = var.container_memory
+      memoryReservation      = var.container_memory_reservation
+      cpu                    = var.container_cpu
+      essential              = var.essential
+      entryPoint             = var.entrypoint
+      command                = var.container_command
+      workingDirectory       = var.working_directory
+      readonlyRootFilesystem = var.readonly_root_filesystem
+      dockerLabels           = local.docker_labels
+      privileged             = var.privileged
+      hostname               = var.hostname
+      environment            = [null_resource.envvars_as_list_of_maps.*.triggers]
+      secrets                = [null_resource.secrets_as_list_of_maps.*.triggers]
+      mountPoints            = [var.mountpoints]
+      portMappings           = local.port_mappings[local.use_port]
+      healthCheck            = var.healthcheck
+      repositoryCredentials  = local.repository_credentials[local.use_credentials]
+      linuxParameters = {
+        initProcessEnabled = var.container_init_process_enabled ? true : false
+      }
+      ulimits = local.ulimits[local.use_ulimits]
+      logConfiguration = {
+        logDriver = var.log_driver
+        options   = var.log_options
+      }
+    },
+  ]
 }
+

--- a/modules/ecs_container_definition/main.tf
+++ b/modules/ecs_container_definition/main.tf
@@ -53,6 +53,35 @@ locals {
   use_credentials = var.repository_credentials_secret_arn == null ? "without_credentials" : "with_credentials"
   use_ulimits     = var.ulimit_soft_limit == "" && var.ulimit_hard_limit == "" ? "without_ulimits" : "with_ulimits"
 
+  # var.healthcheck_cmd can be either a string (to be passed to a
+  # shell) or a list of strings to be executed directly. Terraform
+  # makes this a little tricky.
+  healthcheck_sh   = (
+    var.healthcheck_cmd != null
+    ? try(concat(["CMD-SHELL"], [tostring(var.healthcheck_cmd)]), null)
+    : null)
+  healthcheck_list = (
+    var.healthcheck_cmd != null
+    ? try(concat(["CMD"], tolist(var.healthcheck_cmd)), null)
+    : null)
+  # If healthcheck_cmd is non-null, exactly one of healthcheck_sh and
+  # healthcheck_list will also be.
+  healthcheck_cmd_arg  = (
+    var.healthcheck_cmd != null
+    ? coalesce(tolist(local.healthcheck_sh), tolist(local.healthcheck_list))
+    : null)
+
+  healthcheck_opts = (
+    local.healthcheck_cmd_arg != null
+    ? {
+      command     = local.healthcheck_cmd_arg,
+      interval    = lookup(var.healthcheck_timings, "interval", null),
+      retries     = lookup(var.healthcheck_timings, "retries", null),
+      startPeriod = lookup(var.healthcheck_timings, "startPeriod", null),
+      timeout     = lookup(var.healthcheck_timings, "timeout", null),
+    }
+    : null)
+
   container_definitions = [
     {
       name                   = var.container_name
@@ -72,7 +101,7 @@ locals {
       secrets                = local.secrets_as_list_of_maps
       mountPoints            = var.mountpoints
       portMappings           = local.port_mappings[local.use_port]
-      healthCheck            = var.healthcheck
+      healthCheck            = local.healthcheck_opts
       repositoryCredentials  = local.repository_credentials[local.use_credentials]
       linuxParameters = {
         initProcessEnabled = var.container_init_process_enabled ? true : false

--- a/modules/ecs_container_definition/main.tf
+++ b/modules/ecs_container_definition/main.tf
@@ -46,11 +46,11 @@ locals {
     with_credentials = {
       credentialsParameter = var.repository_credentials_secret_arn
     }
-    without_credentials = {}
+    without_credentials = null
   }
 
   use_port        = var.container_port == "" ? "without_port" : "with_port"
-  use_credentials = var.repository_credentials_secret_arn == "" ? "without_credentials" : "with_credentials"
+  use_credentials = var.repository_credentials_secret_arn == null ? "without_credentials" : "with_credentials"
   use_ulimits     = var.ulimit_soft_limit == "" && var.ulimit_hard_limit == "" ? "without_ulimits" : "with_ulimits"
 
   container_definitions = [

--- a/modules/ecs_container_definition/outputs.tf
+++ b/modules/ecs_container_definition/outputs.tf
@@ -12,5 +12,18 @@ output "json" {
   #  - Convert `"true"` and `"false"` to `true` and `false`
   #  - Convert quoted numbers (e.g. `"123"`) to `123`.
   # Environment variables are kept as strings.
-  value = "${replace(replace(replace(jsonencode(local.container_definitions), "/(\\[\\]|\\[\"\"\\]|\"\"|{})/", "null"), "/(\"[^v][[:alpha:]]+\":)\"([0-9]+\\.?[0-9]*|true|false)\"/", "$1$2"),local.safe_search_replace_string,"")}"
+  value = replace(
+    replace(
+      replace(
+        jsonencode(local.container_definitions),
+        "/(\\[\\]|\\[\"\"\\]|\"\"|{})/",
+        "null",
+      ),
+      "/(\"[^v][[:alpha:]]+\":)\"([0-9]+\\.?[0-9]*|true|false)\"/",
+      "$1$2",
+    ),
+    local.safe_search_replace_string,
+    "",
+  )
 }
+

--- a/modules/ecs_container_definition/variables.tf
+++ b/modules/ecs_container_definition/variables.tf
@@ -26,6 +26,11 @@ variable "container_port" {
   default     = 80
 }
 
+variable "extra_ports" {
+  description = "Port mappings to apply besides the default"
+  default = []
+}
+
 variable "container_init_process_enabled" {
   description = "Should the container be run with initProcessEnabled (--init)"
   default     = false

--- a/modules/ecs_container_definition/variables.tf
+++ b/modules/ecs_container_definition/variables.tf
@@ -45,8 +45,13 @@ variable "privileged" {
   default     = "false"
 }
 
-variable "healthcheck" {
-  description = "A map containing command (string), interval (duration in seconds), retries (1-10, number of times to retry before marking container unhealthy, and startPeriod (0-300, optional grace period to wait, in seconds, before failed healthchecks count toward retries)"
+variable "healthcheck_cmd" {
+  description = "A health check command, as either a list of arguments to be run directly with the 'CMD' tag or a string to be run via a shell with the 'CMD-SHELL' tag."
+  default     = null
+}
+
+variable "healthcheck_timings" {
+  description = "A map containing command (string), interval (duration in seconds), retries (1-10, number of times to retry before marking container unhealthy, startPeriod (0-300, optional grace period to wait, in seconds, before failed healthchecks count toward retries), and timeout (2-60, min. 2, time to wait for a health check to succeed)."
   default     = null
 }
 

--- a/modules/ecs_container_definition/variables.tf
+++ b/modules/ecs_container_definition/variables.tf
@@ -85,7 +85,9 @@ variable "container_secrets" {
     The environment variables to pass to the container as SSM keys. 
     The keys will be looked up and the resulting values will be passed to the environment variable.
     This is a map
-  EOF
+  
+EOF
+
 
   default = {}
 }
@@ -102,9 +104,8 @@ variable "log_driver" {
 
 # list of mount points to add to every container in the task
 variable "mountpoints" {
-  type    = "list"
+  type    = list(map(string))
   default = []
-
   # {
   #   source_volume = "service-storage"
   #   container_path = "/foo"
@@ -121,10 +122,8 @@ variable "log_options" {
   description = "The configuration options to send to the log_driver."
 
   default = {
-    "awslogs-region" = "us-west-2"
-
-    "awslogs-group" = "default"
-
+    "awslogs-region"        = "us-west-2"
+    "awslogs-group"         = "default"
     "awslogs-stream-prefix" = "default"
   }
 }
@@ -132,7 +131,7 @@ variable "log_options" {
 # container_docker_labels sets the DockerLabels, in case it''s set, an extra
 # label '_airship_dockerlabel_hash' is set to keep track of changes.
 variable "container_docker_labels" {
-  type    = "map"
+  type    = map(string)
   default = {}
 }
 
@@ -142,50 +141,50 @@ locals {
   # if the signummed length of the input map is 0 we merge with an empty map, effectively doing nothing.
   docker_label_merge = {
     "0" = {}
-
     "1" = {
-      _airship_dockerlabel_hash = "${md5(jsonencode(var.container_docker_labels))}"
+      _airship_dockerlabel_hash = md5(jsonencode(var.container_docker_labels))
     }
   }
 
   # Secrets aren't trackable by the live_task_loop (thanks AWS!), so we store a hash of them as a synthetic Docker label on the container.
   secrets_merge = {
     "0" = {}
-
     "1" = {
-      _airship_secrets_hash = "${md5(jsonencode(var.container_secrets))}"
+      _airship_secrets_hash = md5(jsonencode(var.container_secrets))
     }
   }
 
-  docker_labels = "${merge(
-     var.container_docker_labels,
-     local.docker_label_merge[signum(length(var.container_docker_labels))],
-     local.secrets_merge[signum(length(var.container_secrets))])}"
+  docker_labels = merge(
+    var.container_docker_labels,
+    local.docker_label_merge[signum(length(var.container_docker_labels))],
+    local.secrets_merge[signum(length(var.container_secrets))],
+  )
 }
 
 variable "tags" {
   description = "A map of tags to apply to all taggable resources"
-  type        = "map"
+  type        = map(string)
   default     = {}
 }
 
 variable "repository_credentials_secret_arn" {
   description = "ARN of Docker private registry credentials stored in secrets manager"
-  type        = "string"
+  type        = string
   default     = ""
 }
 
 variable "ulimit_name" {
-  type    = "string"
+  type    = string
   default = "nofile"
 }
 
 variable "ulimit_soft_limit" {
-  type    = "string"
+  type    = string
   default = ""
 }
 
 variable "ulimit_hard_limit" {
-  type    = "string"
+  type    = string
   default = ""
 }
+

--- a/modules/ecs_container_definition/variables.tf
+++ b/modules/ecs_container_definition/variables.tf
@@ -47,7 +47,7 @@ variable "privileged" {
 
 variable "healthcheck" {
   description = "A map containing command (string), interval (duration in seconds), retries (1-10, number of times to retry before marking container unhealthy, and startPeriod (0-300, optional grace period to wait, in seconds, before failed healthchecks count toward retries)"
-  default     = {}
+  default     = null
 }
 
 variable "container_cpu" {
@@ -62,12 +62,12 @@ variable "essential" {
 
 variable "entrypoint" {
   description = "The entry point that is passed to the container."
-  default     = [""]
+  default     = null
 }
 
 variable "container_command" {
   description = "The command that is passed to the container."
-  default     = [""]
+  default     = null
 }
 
 variable "working_directory" {
@@ -115,7 +115,7 @@ variable "mountpoints" {
 
 variable "hostname" {
   description = "The optional hostname for the container, not allowed to use with Fargate"
-  default     = ""
+  default     = null
 }
 
 variable "log_options" {

--- a/modules/ecs_service/main.tf
+++ b/modules/ecs_service/main.tf
@@ -4,73 +4,73 @@
 #
 
 locals {
-  lb_attached = "${lower(var.load_balancing_type) != "none"}"
+  lb_attached = lower(var.load_balancing_type) != "none"
 }
 
 # Make an LB connected service dependent of this rule
 # This to make sure the Target Group is linked to a Load Balancer before the aws_ecs_service is created
 resource "null_resource" "aws_lb_listener_rules" {
-  count = "${var.create ? 1 : 0}"
+  count = var.create ? 1 : 0
 
-  triggers {
-    listeners = "${join(",", var.aws_lb_listener_rules)}"
+  triggers = {
+    listeners = join(",", var.aws_lb_listener_rules)
   }
 }
 
 resource "aws_ecs_service" "app_with_lb_awsvpc" {
-  count = "${var.create && var.awsvpc_enabled && local.lb_attached && !var.service_discovery_enabled ? 1 : 0}"
+  count = var.create && var.awsvpc_enabled && local.lb_attached && false == var.service_discovery_enabled ? 1 : 0
 
-  name    = "${var.name}"
-  cluster = "${var.cluster_id}"
+  name    = var.name
+  cluster = var.cluster_id
 
-  task_definition                    = "${var.selected_task_definition}"
-  desired_count                      = "${var.desired_capacity}"
-  launch_type                        = "${var.launch_type}"
-  scheduling_strategy                = "${var.scheduling_strategy}"
-  deployment_maximum_percent         = "${var.deployment_maximum_percent}"
-  deployment_minimum_healthy_percent = "${var.deployment_minimum_healthy_percent}"
-  health_check_grace_period_seconds  = "${var.health_check_grace_period_seconds}"
+  task_definition                    = var.selected_task_definition
+  desired_count                      = var.desired_capacity
+  launch_type                        = var.launch_type
+  scheduling_strategy                = var.scheduling_strategy
+  deployment_maximum_percent         = var.deployment_maximum_percent
+  deployment_minimum_healthy_percent = var.deployment_minimum_healthy_percent
+  health_check_grace_period_seconds  = var.health_check_grace_period_seconds
 
   deployment_controller {
-    type = "${var.deployment_controller_type}"
+    type = var.deployment_controller_type
   }
 
   load_balancer {
-    target_group_arn = "${var.lb_target_group_arn}"
-    container_name   = "${var.container_name}"
-    container_port   = "${var.container_port}"
+    target_group_arn = var.lb_target_group_arn
+    container_name   = var.container_name
+    container_port   = var.container_port
   }
 
   lifecycle {
-    ignore_changes = ["desired_count"]
+    ignore_changes = [desired_count]
   }
 
   network_configuration {
-    subnets         = ["${var.awsvpc_subnets}"]
-    security_groups = ["${var.awsvpc_security_group_ids}"]
+    subnets         = var.awsvpc_subnets
+    security_groups = var.awsvpc_security_group_ids
   }
 
-  depends_on = ["null_resource.aws_lb_listener_rules"]
+  depends_on = [null_resource.aws_lb_listener_rules]
 }
 
 resource "aws_ecs_service" "app_with_lb_spread" {
-  count = "${var.create && !var.awsvpc_enabled && local.lb_attached && var.with_placement_strategy && !var.service_discovery_enabled ? 1 : 0}"
+  count = var.create && false == var.awsvpc_enabled && local.lb_attached && var.with_placement_strategy && false == var.service_discovery_enabled ? 1 : 0
 
-  name        = "${var.name}"
-  launch_type = "${var.launch_type}"
-  cluster     = "${var.cluster_id}"
+  name        = var.name
+  launch_type = var.launch_type
+  cluster     = var.cluster_id
 
-  task_definition = "${var.selected_task_definition}"
+  task_definition = var.selected_task_definition
 
-  desired_count       = "${var.desired_capacity}"
-  scheduling_strategy = "${var.scheduling_strategy}"
+  desired_count       = var.desired_capacity
+  scheduling_strategy = var.scheduling_strategy
 
-  deployment_maximum_percent         = "${var.deployment_maximum_percent}"
-  deployment_minimum_healthy_percent = "${var.deployment_minimum_healthy_percent}"
-  health_check_grace_period_seconds  = "${var.health_check_grace_period_seconds}"
+  deployment_maximum_percent         = var.deployment_maximum_percent
+  deployment_minimum_healthy_percent = var.deployment_minimum_healthy_percent
+  health_check_grace_period_seconds  = var.health_check_grace_period_seconds
 
   deployment_controller {
-    type = "${var.deployment_controller_type}"
+    type = var.deployment_controller_type
   }
 
   ordered_placement_strategy {
@@ -89,96 +89,96 @@ resource "aws_ecs_service" "app_with_lb_spread" {
   }
 
   load_balancer {
-    target_group_arn = "${var.lb_target_group_arn}"
-    container_name   = "${var.container_name}"
-    container_port   = "${var.container_port}"
+    target_group_arn = var.lb_target_group_arn
+    container_name   = var.container_name
+    container_port   = var.container_port
   }
 
   lifecycle {
-    ignore_changes = ["desired_count"]
+    ignore_changes = [desired_count]
   }
 
-  depends_on = ["null_resource.aws_lb_listener_rules"]
+  depends_on = [null_resource.aws_lb_listener_rules]
 }
 
 resource "aws_ecs_service" "app_with_lb" {
-  count           = "${var.create && !var.awsvpc_enabled && local.lb_attached && !var.with_placement_strategy && !var.service_discovery_enabled ? 1 : 0}"
-  name            = "${var.name}"
-  launch_type     = "${var.launch_type}"
-  cluster         = "${var.cluster_id}"
-  task_definition = "${var.selected_task_definition}"
+  count           = var.create && false == var.awsvpc_enabled && local.lb_attached && false == var.with_placement_strategy && false == var.service_discovery_enabled ? 1 : 0
+  name            = var.name
+  launch_type     = var.launch_type
+  cluster         = var.cluster_id
+  task_definition = var.selected_task_definition
 
-  desired_count       = "${var.desired_capacity}"
-  scheduling_strategy = "${var.scheduling_strategy}"
+  desired_count       = var.desired_capacity
+  scheduling_strategy = var.scheduling_strategy
 
-  deployment_maximum_percent         = "${var.deployment_maximum_percent}"
-  deployment_minimum_healthy_percent = "${var.deployment_minimum_healthy_percent}"
-  health_check_grace_period_seconds  = "${var.health_check_grace_period_seconds}"
+  deployment_maximum_percent         = var.deployment_maximum_percent
+  deployment_minimum_healthy_percent = var.deployment_minimum_healthy_percent
+  health_check_grace_period_seconds  = var.health_check_grace_period_seconds
 
   deployment_controller {
-    type = "${var.deployment_controller_type}"
+    type = var.deployment_controller_type
   }
 
   load_balancer {
-    target_group_arn = "${var.lb_target_group_arn}"
-    container_name   = "${var.container_name}"
-    container_port   = "${var.container_port}"
+    target_group_arn = var.lb_target_group_arn
+    container_name   = var.container_name
+    container_port   = var.container_port
   }
 
   lifecycle {
-    ignore_changes = ["desired_count"]
+    ignore_changes = [desired_count]
   }
 
-  depends_on = ["null_resource.aws_lb_listener_rules"]
+  depends_on = [null_resource.aws_lb_listener_rules]
 }
 
 resource "aws_ecs_service" "app" {
-  count = "${var.create && ! local.lb_attached && ! var.awsvpc_enabled && !var.service_discovery_enabled ? 1 : 0 }"
+  count = var.create && false == local.lb_attached && false == var.awsvpc_enabled && false == var.service_discovery_enabled ? 1 : 0
 
-  name                = "${var.name}"
-  launch_type         = "${var.launch_type}"
-  scheduling_strategy = "${var.scheduling_strategy}"
-  cluster             = "${var.cluster_id}"
-  task_definition     = "${var.selected_task_definition}"
+  name                = var.name
+  launch_type         = var.launch_type
+  scheduling_strategy = var.scheduling_strategy
+  cluster             = var.cluster_id
+  task_definition     = var.selected_task_definition
 
-  desired_count = "${var.desired_capacity}"
+  desired_count = var.desired_capacity
 
-  deployment_maximum_percent         = "${var.deployment_maximum_percent}"
-  deployment_minimum_healthy_percent = "${var.deployment_minimum_healthy_percent}"
+  deployment_maximum_percent         = var.deployment_maximum_percent
+  deployment_minimum_healthy_percent = var.deployment_minimum_healthy_percent
 
   deployment_controller {
-    type = "${var.deployment_controller_type}"
+    type = var.deployment_controller_type
   }
 
   lifecycle {
-    ignore_changes = ["desired_count"]
+    ignore_changes = [desired_count]
   }
 }
 
 resource "aws_ecs_service" "app_awsvpc" {
-  count = "${var.create && ! local.lb_attached && var.awsvpc_enabled && !var.service_discovery_enabled ? 1 : 0 }"
+  count = var.create && false == local.lb_attached && var.awsvpc_enabled && false == var.service_discovery_enabled ? 1 : 0
 
-  name                = "${var.name}"
-  launch_type         = "${var.launch_type}"
-  scheduling_strategy = "${var.scheduling_strategy}"
-  cluster             = "${var.cluster_id}"
-  task_definition     = "${var.selected_task_definition}"
-  desired_count       = "${var.desired_capacity}"
+  name                = var.name
+  launch_type         = var.launch_type
+  scheduling_strategy = var.scheduling_strategy
+  cluster             = var.cluster_id
+  task_definition     = var.selected_task_definition
+  desired_count       = var.desired_capacity
 
-  deployment_maximum_percent         = "${var.deployment_maximum_percent}"
-  deployment_minimum_healthy_percent = "${var.deployment_minimum_healthy_percent}"
+  deployment_maximum_percent         = var.deployment_maximum_percent
+  deployment_minimum_healthy_percent = var.deployment_minimum_healthy_percent
 
   deployment_controller {
-    type = "${var.deployment_controller_type}"
+    type = var.deployment_controller_type
   }
 
   network_configuration {
-    subnets         = ["${var.awsvpc_subnets}"]
-    security_groups = ["${var.awsvpc_security_group_ids}"]
+    subnets         = var.awsvpc_subnets
+    security_groups = var.awsvpc_security_group_ids
   }
 
   lifecycle {
-    ignore_changes = ["desired_count"]
+    ignore_changes = [desired_count]
   }
 }
 
@@ -188,89 +188,89 @@ locals {
   # service_registries block does not accept a port with "A"-record-type
   # Setting the port to false works through a local
   service_registries_container_port = {
-    "SRV" = "${var.container_port}"
+    "SRV" = var.container_port
     "A"   = false
   }
 }
 
 resource "aws_service_discovery_service" "service" {
-  count = "${var.create && var.service_discovery_enabled ? 1 : 0}"
+  count = var.create && var.service_discovery_enabled ? 1 : 0
 
-  name = "${var.name}"
+  name = var.name
 
   dns_config {
-    namespace_id = "${var.service_discovery_namespace_id}"
+    namespace_id = var.service_discovery_namespace_id
 
     dns_records {
-      ttl  = "${var.service_discovery_dns_ttl}"
-      type = "${var.service_discovery_dns_type}"
+      ttl  = var.service_discovery_dns_ttl
+      type = var.service_discovery_dns_type
     }
 
-    routing_policy = "${var.service_discovery_routing_policy}"
+    routing_policy = var.service_discovery_routing_policy
   }
 
   health_check_custom_config {
-    failure_threshold = "${var.service_discovery_healthcheck_custom_failure_threshold}"
+    failure_threshold = var.service_discovery_healthcheck_custom_failure_threshold
   }
 }
 
 resource "aws_ecs_service" "app_with_lb_awsvpc_with_service_registry" {
-  count = "${var.create && var.awsvpc_enabled && local.lb_attached && var.service_discovery_enabled ? 1 : 0}"
+  count = var.create && var.awsvpc_enabled && local.lb_attached && var.service_discovery_enabled ? 1 : 0
 
-  name    = "${var.name}"
-  cluster = "${var.cluster_id}"
+  name    = var.name
+  cluster = var.cluster_id
 
-  task_definition                    = "${var.selected_task_definition}"
-  desired_count                      = "${var.desired_capacity}"
-  launch_type                        = "${var.launch_type}"
-  scheduling_strategy                = "${var.scheduling_strategy}"
-  deployment_maximum_percent         = "${var.deployment_maximum_percent}"
-  deployment_minimum_healthy_percent = "${var.deployment_minimum_healthy_percent}"
+  task_definition                    = var.selected_task_definition
+  desired_count                      = var.desired_capacity
+  launch_type                        = var.launch_type
+  scheduling_strategy                = var.scheduling_strategy
+  deployment_maximum_percent         = var.deployment_maximum_percent
+  deployment_minimum_healthy_percent = var.deployment_minimum_healthy_percent
 
   deployment_controller {
-    type = "${var.deployment_controller_type}"
+    type = var.deployment_controller_type
   }
 
   load_balancer {
-    target_group_arn = "${var.lb_target_group_arn}"
-    container_name   = "${var.container_name}"
-    container_port   = "${var.container_port}"
+    target_group_arn = var.lb_target_group_arn
+    container_name   = var.container_name
+    container_port   = var.container_port
   }
 
   lifecycle {
-    ignore_changes = ["desired_count"]
+    ignore_changes = [desired_count]
   }
 
   network_configuration {
-    subnets         = ["${var.awsvpc_subnets}"]
-    security_groups = ["${var.awsvpc_security_group_ids}"]
+    subnets         = var.awsvpc_subnets
+    security_groups = var.awsvpc_security_group_ids
   }
 
-  service_registries = {
-    registry_arn   = "${aws_service_discovery_service.service.arn}"
-    container_name = "${var.container_name}"
-    container_port = "${local.service_registries_container_port[var.service_discovery_dns_type]}"
+  service_registries {
+    registry_arn   = aws_service_discovery_service.service[0].arn
+    container_name = var.container_name
+    container_port = local.service_registries_container_port[var.service_discovery_dns_type]
   }
 
-  depends_on = ["null_resource.aws_lb_listener_rules"]
+  depends_on = [null_resource.aws_lb_listener_rules]
 }
 
 resource "aws_ecs_service" "app_with_lb_spread_with_service_registry" {
-  count       = "${var.create && !var.awsvpc_enabled && local.lb_attached && var.with_placement_strategy && var.service_discovery_enabled ? 1 : 0}"
-  name        = "${var.name}"
-  launch_type = "${var.launch_type}"
-  cluster     = "${var.cluster_id}"
+  count       = var.create && false == var.awsvpc_enabled && local.lb_attached && var.with_placement_strategy && var.service_discovery_enabled ? 1 : 0
+  name        = var.name
+  launch_type = var.launch_type
+  cluster     = var.cluster_id
 
-  task_definition = "${var.selected_task_definition}"
+  task_definition = var.selected_task_definition
 
-  desired_count       = "${var.desired_capacity}"
-  scheduling_strategy = "${var.scheduling_strategy}"
+  desired_count       = var.desired_capacity
+  scheduling_strategy = var.scheduling_strategy
 
-  deployment_maximum_percent         = "${var.deployment_maximum_percent}"
-  deployment_minimum_healthy_percent = "${var.deployment_minimum_healthy_percent}"
+  deployment_maximum_percent         = var.deployment_maximum_percent
+  deployment_minimum_healthy_percent = var.deployment_minimum_healthy_percent
 
   deployment_controller {
-    type = "${var.deployment_controller_type}"
+    type = var.deployment_controller_type
   }
 
   ordered_placement_strategy {
@@ -289,118 +289,119 @@ resource "aws_ecs_service" "app_with_lb_spread_with_service_registry" {
   }
 
   load_balancer {
-    target_group_arn = "${var.lb_target_group_arn}"
-    container_name   = "${var.container_name}"
-    container_port   = "${var.container_port}"
+    target_group_arn = var.lb_target_group_arn
+    container_name   = var.container_name
+    container_port   = var.container_port
   }
 
   lifecycle {
-    ignore_changes = ["desired_count"]
+    ignore_changes = [desired_count]
   }
 
-  service_registries = {
-    registry_arn   = "${aws_service_discovery_service.service.arn}"
-    container_name = "${var.container_name}"
-    container_port = "${local.service_registries_container_port[var.service_discovery_dns_type]}"
+  service_registries {
+    registry_arn   = aws_service_discovery_service.service[0].arn
+    container_name = var.container_name
+    container_port = local.service_registries_container_port[var.service_discovery_dns_type]
   }
 
-  depends_on = ["null_resource.aws_lb_listener_rules"]
+  depends_on = [null_resource.aws_lb_listener_rules]
 }
 
 resource "aws_ecs_service" "app_with_lb_with_service_registry" {
-  count           = "${var.create && !var.awsvpc_enabled && local.lb_attached && !var.with_placement_strategy && var.service_discovery_enabled ? 1 : 0}"
-  name            = "${var.name}"
-  launch_type     = "${var.launch_type}"
-  cluster         = "${var.cluster_id}"
-  task_definition = "${var.selected_task_definition}"
+  count           = var.create && false == var.awsvpc_enabled && local.lb_attached && false == var.with_placement_strategy && var.service_discovery_enabled ? 1 : 0
+  name            = var.name
+  launch_type     = var.launch_type
+  cluster         = var.cluster_id
+  task_definition = var.selected_task_definition
 
-  desired_count       = "${var.desired_capacity}"
-  scheduling_strategy = "${var.scheduling_strategy}"
+  desired_count       = var.desired_capacity
+  scheduling_strategy = var.scheduling_strategy
 
-  deployment_maximum_percent         = "${var.deployment_maximum_percent}"
-  deployment_minimum_healthy_percent = "${var.deployment_minimum_healthy_percent}"
+  deployment_maximum_percent         = var.deployment_maximum_percent
+  deployment_minimum_healthy_percent = var.deployment_minimum_healthy_percent
 
   deployment_controller {
-    type = "${var.deployment_controller_type}"
+    type = var.deployment_controller_type
   }
 
   load_balancer {
-    target_group_arn = "${var.lb_target_group_arn}"
-    container_name   = "${var.container_name}"
-    container_port   = "${var.container_port}"
+    target_group_arn = var.lb_target_group_arn
+    container_name   = var.container_name
+    container_port   = var.container_port
   }
 
   lifecycle {
-    ignore_changes = ["desired_count"]
+    ignore_changes = [desired_count]
   }
 
-  service_registries = {
-    registry_arn   = "${aws_service_discovery_service.service.arn}"
-    container_name = "${var.container_name}"
-    container_port = "${local.service_registries_container_port[var.service_discovery_dns_type]}"
+  service_registries {
+    registry_arn   = aws_service_discovery_service.service[0].arn
+    container_name = var.container_name
+    container_port = local.service_registries_container_port[var.service_discovery_dns_type]
   }
 
-  depends_on = ["null_resource.aws_lb_listener_rules"]
+  depends_on = [null_resource.aws_lb_listener_rules]
 }
 
 resource "aws_ecs_service" "app_with_service_registry" {
-  count = "${var.create && ! local.lb_attached && ! var.awsvpc_enabled && var.service_discovery_enabled ? 1 : 0 }"
+  count = var.create && false == local.lb_attached && false == var.awsvpc_enabled && var.service_discovery_enabled ? 1 : 0
 
-  name                = "${var.name}"
-  launch_type         = "${var.launch_type}"
-  scheduling_strategy = "${var.scheduling_strategy}"
-  cluster             = "${var.cluster_id}"
-  task_definition     = "${var.selected_task_definition}"
+  name                = var.name
+  launch_type         = var.launch_type
+  scheduling_strategy = var.scheduling_strategy
+  cluster             = var.cluster_id
+  task_definition     = var.selected_task_definition
 
-  desired_count = "${var.desired_capacity}"
+  desired_count = var.desired_capacity
 
-  deployment_maximum_percent         = "${var.deployment_maximum_percent}"
-  deployment_minimum_healthy_percent = "${var.deployment_minimum_healthy_percent}"
+  deployment_maximum_percent         = var.deployment_maximum_percent
+  deployment_minimum_healthy_percent = var.deployment_minimum_healthy_percent
 
   deployment_controller {
-    type = "${var.deployment_controller_type}"
+    type = var.deployment_controller_type
   }
 
-  service_registries = {
-    registry_arn   = "${aws_service_discovery_service.service.arn}"
-    container_name = "${var.container_name}"
-    container_port = "${local.service_registries_container_port[var.service_discovery_dns_type]}"
+  service_registries {
+    registry_arn   = aws_service_discovery_service.service[0].arn
+    container_name = var.container_name
+    container_port = local.service_registries_container_port[var.service_discovery_dns_type]
   }
 
   lifecycle {
-    ignore_changes = ["desired_count"]
+    ignore_changes = [desired_count]
   }
 }
 
 resource "aws_ecs_service" "app_awsvpc_with_service_registry" {
-  count = "${var.create && ! local.lb_attached && var.awsvpc_enabled && var.service_discovery_enabled ? 1 : 0 }"
+  count = var.create && false == local.lb_attached && var.awsvpc_enabled && var.service_discovery_enabled ? 1 : 0
 
-  name                = "${var.name}"
-  launch_type         = "${var.launch_type}"
-  scheduling_strategy = "${var.scheduling_strategy}"
-  cluster             = "${var.cluster_id}"
-  task_definition     = "${var.selected_task_definition}"
-  desired_count       = "${var.desired_capacity}"
+  name                = var.name
+  launch_type         = var.launch_type
+  scheduling_strategy = var.scheduling_strategy
+  cluster             = var.cluster_id
+  task_definition     = var.selected_task_definition
+  desired_count       = var.desired_capacity
 
-  deployment_maximum_percent         = "${var.deployment_maximum_percent}"
-  deployment_minimum_healthy_percent = "${var.deployment_minimum_healthy_percent}"
+  deployment_maximum_percent         = var.deployment_maximum_percent
+  deployment_minimum_healthy_percent = var.deployment_minimum_healthy_percent
 
   deployment_controller {
-    type = "${var.deployment_controller_type}"
+    type = var.deployment_controller_type
   }
 
   network_configuration {
-    subnets         = ["${var.awsvpc_subnets}"]
-    security_groups = ["${var.awsvpc_security_group_ids}"]
+    subnets         = var.awsvpc_subnets
+    security_groups = var.awsvpc_security_group_ids
   }
 
-  service_registries = {
-    registry_arn   = "${aws_service_discovery_service.service.arn}"
-    container_name = "${var.container_name}"
-    container_port = "${local.service_registries_container_port[var.service_discovery_dns_type]}"
+  service_registries {
+    registry_arn   = aws_service_discovery_service.service[0].arn
+    container_name = var.container_name
+    container_port = local.service_registries_container_port[var.service_discovery_dns_type]
   }
 
   lifecycle {
-    ignore_changes = ["desired_count"]
+    ignore_changes = [desired_count]
   }
 }
+

--- a/modules/ecs_service/main.tf
+++ b/modules/ecs_service/main.tf
@@ -68,6 +68,7 @@ resource "aws_ecs_service" "this" {
     content {
       subnets          = var.awsvpc_subnets
       security_groups  = var.awsvpc_security_group_ids
+      assign_public_ip = var.assign_public_ip
     }
   }
 

--- a/modules/ecs_service/main.tf
+++ b/modules/ecs_service/main.tf
@@ -24,7 +24,7 @@ resource "aws_ecs_service" "this" {
   scheduling_strategy                = var.scheduling_strategy
   deployment_maximum_percent         = var.deployment_maximum_percent
   deployment_minimum_healthy_percent = var.deployment_minimum_healthy_percent
-  health_check_grace_period_seconds  = var.health_check_grace_period_seconds
+  health_check_grace_period_seconds  = local.lb_attached ? var.health_check_grace_period_seconds : null
 
   deployment_controller {
     type = var.deployment_controller_type

--- a/modules/ecs_service/main.tf
+++ b/modules/ecs_service/main.tf
@@ -95,7 +95,7 @@ locals {
   # Setting the port to false works through a local
   service_registries_container_port = {
     "SRV" = var.container_port
-    "A"   = false
+    "A"   = null
   }
 }
 

--- a/modules/ecs_service/main.tf
+++ b/modules/ecs_service/main.tf
@@ -1,8 +1,3 @@
-#
-# With HCL1 it's not possible to add dynamic blocks for the aws_ecs_service resource. For this
-# reason many aws_ecs_service's are repeated for their different goals.
-#
-
 locals {
   lb_attached = lower(var.load_balancing_type) != "none"
 }
@@ -17,8 +12,8 @@ resource "null_resource" "aws_lb_listener_rules" {
   }
 }
 
-resource "aws_ecs_service" "app_with_lb_awsvpc" {
-  count = var.create && var.awsvpc_enabled && local.lb_attached && false == var.service_discovery_enabled ? 1 : 0
+resource "aws_ecs_service" "this" {
+  count = var.create ? 1 : 0
 
   name    = var.name
   cluster = var.cluster_id
@@ -35,63 +30,54 @@ resource "aws_ecs_service" "app_with_lb_awsvpc" {
     type = var.deployment_controller_type
   }
 
-  load_balancer {
-    target_group_arn = var.lb_target_group_arn
-    container_name   = var.container_name
-    container_port   = var.container_port
+  dynamic ordered_placement_strategy {
+    for_each = var.with_placement_strategy ? [1] : []
+    content {
+      field = "attribute:ecs.availability-zone"
+      type  = "spread"
+    }
   }
 
-  lifecycle {
-    ignore_changes = [desired_count]
+  dynamic ordered_placement_strategy {
+    for_each = var.with_placement_strategy ? [1] : []
+    content {
+      field = "instanceId"
+      type  = "spread"
+    }
   }
 
-  network_configuration {
-    subnets         = var.awsvpc_subnets
-    security_groups = var.awsvpc_security_group_ids
+  dynamic ordered_placement_strategy {
+    for_each = var.with_placement_strategy ? [1] : []
+    content {
+      field = "memory"
+      type  = "binpack"
+    }
   }
 
-  depends_on = [null_resource.aws_lb_listener_rules]
-}
-
-resource "aws_ecs_service" "app_with_lb_spread" {
-  count = var.create && false == var.awsvpc_enabled && local.lb_attached && var.with_placement_strategy && false == var.service_discovery_enabled ? 1 : 0
-
-  name        = var.name
-  launch_type = var.launch_type
-  cluster     = var.cluster_id
-
-  task_definition = var.selected_task_definition
-
-  desired_count       = var.desired_capacity
-  scheduling_strategy = var.scheduling_strategy
-
-  deployment_maximum_percent         = var.deployment_maximum_percent
-  deployment_minimum_healthy_percent = var.deployment_minimum_healthy_percent
-  health_check_grace_period_seconds  = var.health_check_grace_period_seconds
-
-  deployment_controller {
-    type = var.deployment_controller_type
+  dynamic load_balancer {
+    for_each = local.lb_attached ? [1] : []
+    content {
+      target_group_arn = var.lb_target_group_arn
+      container_name   = var.container_name
+      container_port   = var.container_port
+    }
   }
 
-  ordered_placement_strategy {
-    field = "attribute:ecs.availability-zone"
-    type  = "spread"
+  dynamic network_configuration {
+    for_each = var.awsvpc_enabled ? [1] : []
+    content {
+      subnets          = var.awsvpc_subnets
+      security_groups  = var.awsvpc_security_group_ids
+    }
   }
 
-  ordered_placement_strategy {
-    field = "instanceId"
-    type  = "spread"
-  }
-
-  ordered_placement_strategy {
-    field = "memory"
-    type  = "binpack"
-  }
-
-  load_balancer {
-    target_group_arn = var.lb_target_group_arn
-    container_name   = var.container_name
-    container_port   = var.container_port
+  dynamic service_registries {
+    for_each = var.service_discovery_enabled ? [1] : []
+    content {
+      registry_arn   = aws_service_discovery_service.this[0].arn
+      container_name = var.container_name
+      container_port = local.service_registries_container_port[var.service_discovery_dns_type]
+    }
   }
 
   lifecycle {
@@ -99,87 +85,6 @@ resource "aws_ecs_service" "app_with_lb_spread" {
   }
 
   depends_on = [null_resource.aws_lb_listener_rules]
-}
-
-resource "aws_ecs_service" "app_with_lb" {
-  count           = var.create && false == var.awsvpc_enabled && local.lb_attached && false == var.with_placement_strategy && false == var.service_discovery_enabled ? 1 : 0
-  name            = var.name
-  launch_type     = var.launch_type
-  cluster         = var.cluster_id
-  task_definition = var.selected_task_definition
-
-  desired_count       = var.desired_capacity
-  scheduling_strategy = var.scheduling_strategy
-
-  deployment_maximum_percent         = var.deployment_maximum_percent
-  deployment_minimum_healthy_percent = var.deployment_minimum_healthy_percent
-  health_check_grace_period_seconds  = var.health_check_grace_period_seconds
-
-  deployment_controller {
-    type = var.deployment_controller_type
-  }
-
-  load_balancer {
-    target_group_arn = var.lb_target_group_arn
-    container_name   = var.container_name
-    container_port   = var.container_port
-  }
-
-  lifecycle {
-    ignore_changes = [desired_count]
-  }
-
-  depends_on = [null_resource.aws_lb_listener_rules]
-}
-
-resource "aws_ecs_service" "app" {
-  count = var.create && false == local.lb_attached && false == var.awsvpc_enabled && false == var.service_discovery_enabled ? 1 : 0
-
-  name                = var.name
-  launch_type         = var.launch_type
-  scheduling_strategy = var.scheduling_strategy
-  cluster             = var.cluster_id
-  task_definition     = var.selected_task_definition
-
-  desired_count = var.desired_capacity
-
-  deployment_maximum_percent         = var.deployment_maximum_percent
-  deployment_minimum_healthy_percent = var.deployment_minimum_healthy_percent
-
-  deployment_controller {
-    type = var.deployment_controller_type
-  }
-
-  lifecycle {
-    ignore_changes = [desired_count]
-  }
-}
-
-resource "aws_ecs_service" "app_awsvpc" {
-  count = var.create && false == local.lb_attached && var.awsvpc_enabled && false == var.service_discovery_enabled ? 1 : 0
-
-  name                = var.name
-  launch_type         = var.launch_type
-  scheduling_strategy = var.scheduling_strategy
-  cluster             = var.cluster_id
-  task_definition     = var.selected_task_definition
-  desired_count       = var.desired_capacity
-
-  deployment_maximum_percent         = var.deployment_maximum_percent
-  deployment_minimum_healthy_percent = var.deployment_minimum_healthy_percent
-
-  deployment_controller {
-    type = var.deployment_controller_type
-  }
-
-  network_configuration {
-    subnets         = var.awsvpc_subnets
-    security_groups = var.awsvpc_security_group_ids
-  }
-
-  lifecycle {
-    ignore_changes = [desired_count]
-  }
 }
 
 ### Service Registry resources
@@ -193,7 +98,7 @@ locals {
   }
 }
 
-resource "aws_service_discovery_service" "service" {
+resource "aws_service_discovery_service" "this" {
   count = var.create && var.service_discovery_enabled ? 1 : 0
 
   name = var.name
@@ -213,195 +118,3 @@ resource "aws_service_discovery_service" "service" {
     failure_threshold = var.service_discovery_healthcheck_custom_failure_threshold
   }
 }
-
-resource "aws_ecs_service" "app_with_lb_awsvpc_with_service_registry" {
-  count = var.create && var.awsvpc_enabled && local.lb_attached && var.service_discovery_enabled ? 1 : 0
-
-  name    = var.name
-  cluster = var.cluster_id
-
-  task_definition                    = var.selected_task_definition
-  desired_count                      = var.desired_capacity
-  launch_type                        = var.launch_type
-  scheduling_strategy                = var.scheduling_strategy
-  deployment_maximum_percent         = var.deployment_maximum_percent
-  deployment_minimum_healthy_percent = var.deployment_minimum_healthy_percent
-
-  deployment_controller {
-    type = var.deployment_controller_type
-  }
-
-  load_balancer {
-    target_group_arn = var.lb_target_group_arn
-    container_name   = var.container_name
-    container_port   = var.container_port
-  }
-
-  lifecycle {
-    ignore_changes = [desired_count]
-  }
-
-  network_configuration {
-    subnets         = var.awsvpc_subnets
-    security_groups = var.awsvpc_security_group_ids
-  }
-
-  service_registries {
-    registry_arn   = aws_service_discovery_service.service[0].arn
-    container_name = var.container_name
-    container_port = local.service_registries_container_port[var.service_discovery_dns_type]
-  }
-
-  depends_on = [null_resource.aws_lb_listener_rules]
-}
-
-resource "aws_ecs_service" "app_with_lb_spread_with_service_registry" {
-  count       = var.create && false == var.awsvpc_enabled && local.lb_attached && var.with_placement_strategy && var.service_discovery_enabled ? 1 : 0
-  name        = var.name
-  launch_type = var.launch_type
-  cluster     = var.cluster_id
-
-  task_definition = var.selected_task_definition
-
-  desired_count       = var.desired_capacity
-  scheduling_strategy = var.scheduling_strategy
-
-  deployment_maximum_percent         = var.deployment_maximum_percent
-  deployment_minimum_healthy_percent = var.deployment_minimum_healthy_percent
-
-  deployment_controller {
-    type = var.deployment_controller_type
-  }
-
-  ordered_placement_strategy {
-    field = "attribute:ecs.availability-zone"
-    type  = "spread"
-  }
-
-  ordered_placement_strategy {
-    field = "instanceId"
-    type  = "spread"
-  }
-
-  ordered_placement_strategy {
-    field = "memory"
-    type  = "binpack"
-  }
-
-  load_balancer {
-    target_group_arn = var.lb_target_group_arn
-    container_name   = var.container_name
-    container_port   = var.container_port
-  }
-
-  lifecycle {
-    ignore_changes = [desired_count]
-  }
-
-  service_registries {
-    registry_arn   = aws_service_discovery_service.service[0].arn
-    container_name = var.container_name
-    container_port = local.service_registries_container_port[var.service_discovery_dns_type]
-  }
-
-  depends_on = [null_resource.aws_lb_listener_rules]
-}
-
-resource "aws_ecs_service" "app_with_lb_with_service_registry" {
-  count           = var.create && false == var.awsvpc_enabled && local.lb_attached && false == var.with_placement_strategy && var.service_discovery_enabled ? 1 : 0
-  name            = var.name
-  launch_type     = var.launch_type
-  cluster         = var.cluster_id
-  task_definition = var.selected_task_definition
-
-  desired_count       = var.desired_capacity
-  scheduling_strategy = var.scheduling_strategy
-
-  deployment_maximum_percent         = var.deployment_maximum_percent
-  deployment_minimum_healthy_percent = var.deployment_minimum_healthy_percent
-
-  deployment_controller {
-    type = var.deployment_controller_type
-  }
-
-  load_balancer {
-    target_group_arn = var.lb_target_group_arn
-    container_name   = var.container_name
-    container_port   = var.container_port
-  }
-
-  lifecycle {
-    ignore_changes = [desired_count]
-  }
-
-  service_registries {
-    registry_arn   = aws_service_discovery_service.service[0].arn
-    container_name = var.container_name
-    container_port = local.service_registries_container_port[var.service_discovery_dns_type]
-  }
-
-  depends_on = [null_resource.aws_lb_listener_rules]
-}
-
-resource "aws_ecs_service" "app_with_service_registry" {
-  count = var.create && false == local.lb_attached && false == var.awsvpc_enabled && var.service_discovery_enabled ? 1 : 0
-
-  name                = var.name
-  launch_type         = var.launch_type
-  scheduling_strategy = var.scheduling_strategy
-  cluster             = var.cluster_id
-  task_definition     = var.selected_task_definition
-
-  desired_count = var.desired_capacity
-
-  deployment_maximum_percent         = var.deployment_maximum_percent
-  deployment_minimum_healthy_percent = var.deployment_minimum_healthy_percent
-
-  deployment_controller {
-    type = var.deployment_controller_type
-  }
-
-  service_registries {
-    registry_arn   = aws_service_discovery_service.service[0].arn
-    container_name = var.container_name
-    container_port = local.service_registries_container_port[var.service_discovery_dns_type]
-  }
-
-  lifecycle {
-    ignore_changes = [desired_count]
-  }
-}
-
-resource "aws_ecs_service" "app_awsvpc_with_service_registry" {
-  count = var.create && false == local.lb_attached && var.awsvpc_enabled && var.service_discovery_enabled ? 1 : 0
-
-  name                = var.name
-  launch_type         = var.launch_type
-  scheduling_strategy = var.scheduling_strategy
-  cluster             = var.cluster_id
-  task_definition     = var.selected_task_definition
-  desired_count       = var.desired_capacity
-
-  deployment_maximum_percent         = var.deployment_maximum_percent
-  deployment_minimum_healthy_percent = var.deployment_minimum_healthy_percent
-
-  deployment_controller {
-    type = var.deployment_controller_type
-  }
-
-  network_configuration {
-    subnets         = var.awsvpc_subnets
-    security_groups = var.awsvpc_security_group_ids
-  }
-
-  service_registries {
-    registry_arn   = aws_service_discovery_service.service[0].arn
-    container_name = var.container_name
-    container_port = local.service_registries_container_port[var.service_discovery_dns_type]
-  }
-
-  lifecycle {
-    ignore_changes = [desired_count]
-  }
-}
-

--- a/modules/ecs_service/main.tf
+++ b/modules/ecs_service/main.tf
@@ -86,6 +86,11 @@ resource "aws_ecs_service" "this" {
   }
 
   depends_on = [null_resource.aws_lb_listener_rules]
+
+  tags = var.tags
+
+  # propagate the service tags to tasks
+  propagate_tags = "SERVICE"
 }
 
 ### Service Registry resources

--- a/modules/ecs_service/output.tf
+++ b/modules/ecs_service/output.tf
@@ -2,15 +2,15 @@
 # Autoscaling uses the service name, by using the service name of the resource output, we make sure that the
 # Order of creation is maintained
 output "ecs_service_name" {
-  value = "${var.service_discovery_enabled ?
-     (var.awsvpc_enabled ? 
-                ( local.lb_attached ? join("",aws_ecs_service.app_with_lb_awsvpc_with_service_registry.*.name) : join("",aws_ecs_service.app_awsvpc_with_service_registry.*.name) ) 
-                :
-                ( local.lb_attached ? ( var.with_placement_strategy ? join("",aws_ecs_service.app_with_lb_spread_with_service_registry.*.name) : join("",aws_ecs_service.app_with_lb_with_service_registry.*.name)) : join("",aws_ecs_service.app_with_lb_awsvpc_with_service_registry.*.name) ))
-                :
-     (var.awsvpc_enabled ? 
-                ( local.lb_attached ? join("",aws_ecs_service.app_with_lb_awsvpc.*.name) : join("",aws_ecs_service.app_awsvpc.*.name) ) 
-                :
-                ( local.lb_attached ? ( var.with_placement_strategy ? join("",aws_ecs_service.app_with_lb_spread.*.name) : join("",aws_ecs_service.app_with_lb.*.name)) : join("",aws_ecs_service.app.*.name) ))
-  }"
+  value = var.service_discovery_enabled ? var.awsvpc_enabled ? local.lb_attached ? join(
+    "",
+    aws_ecs_service.app_with_lb_awsvpc_with_service_registry.*.name,
+    ) : join("", aws_ecs_service.app_awsvpc_with_service_registry.*.name) : local.lb_attached ? var.with_placement_strategy ? join(
+    "",
+    aws_ecs_service.app_with_lb_spread_with_service_registry.*.name,
+    ) : join("", aws_ecs_service.app_with_lb_with_service_registry.*.name) : join(
+    "",
+    aws_ecs_service.app_with_lb_awsvpc_with_service_registry.*.name,
+  ) : var.awsvpc_enabled ? local.lb_attached ? join("", aws_ecs_service.app_with_lb_awsvpc.*.name) : join("", aws_ecs_service.app_awsvpc.*.name) : local.lb_attached ? var.with_placement_strategy ? join("", aws_ecs_service.app_with_lb_spread.*.name) : join("", aws_ecs_service.app_with_lb.*.name) : join("", aws_ecs_service.app.*.name)
 }
+

--- a/modules/ecs_service/output.tf
+++ b/modules/ecs_service/output.tf
@@ -2,15 +2,6 @@
 # Autoscaling uses the service name, by using the service name of the resource output, we make sure that the
 # Order of creation is maintained
 output "ecs_service_name" {
-  value = var.service_discovery_enabled ? var.awsvpc_enabled ? local.lb_attached ? join(
-    "",
-    aws_ecs_service.app_with_lb_awsvpc_with_service_registry.*.name,
-    ) : join("", aws_ecs_service.app_awsvpc_with_service_registry.*.name) : local.lb_attached ? var.with_placement_strategy ? join(
-    "",
-    aws_ecs_service.app_with_lb_spread_with_service_registry.*.name,
-    ) : join("", aws_ecs_service.app_with_lb_with_service_registry.*.name) : join(
-    "",
-    aws_ecs_service.app_with_lb_awsvpc_with_service_registry.*.name,
-  ) : var.awsvpc_enabled ? local.lb_attached ? join("", aws_ecs_service.app_with_lb_awsvpc.*.name) : join("", aws_ecs_service.app_awsvpc.*.name) : local.lb_attached ? var.with_placement_strategy ? join("", aws_ecs_service.app_with_lb_spread.*.name) : join("", aws_ecs_service.app_with_lb.*.name) : join("", aws_ecs_service.app.*.name)
+  value = join("", aws_ecs_service.this.*.name)
 }
 

--- a/modules/ecs_service/variables.tf
+++ b/modules/ecs_service/variables.tf
@@ -1,47 +1,60 @@
 # hack 
 variable "aws_lb_listener_rules" {
+  type    = list(string)
   default = []
 }
 
 # Name of the ECS Service
-variable "name" {}
+variable "name" {
+}
 
 # Do we create resources
 variable "create" {
   default = true
 }
 
-variable "awsvpc_enabled" {}
+variable "awsvpc_enabled" {
+}
 
-variable "selected_task_definition" {}
+variable "selected_task_definition" {
+}
 
 # The cluster ID
-variable "cluster_id" {}
+variable "cluster_id" {
+}
 
 # The launch type, either FARGATE or EC2
-variable "launch_type" {}
+variable "launch_type" {
+}
 
 # The initial desired_capacity
-variable "desired_capacity" {}
+variable "desired_capacity" {
+}
 
 # The container name
-variable "container_name" {}
+variable "container_name" {
+}
 
 # The container port
-variable "container_port" {}
+variable "container_port" {
+}
 
 # scheduling_strategy defaults to Replica
-variable "scheduling_strategy" {}
+variable "scheduling_strategy" {
+}
 
 # deployment_controller_type sets the deployment type
 # ECS for Rolling update, and CODE_DEPLOY for Blue/Green deployment via CodeDeploy
-variable "deployment_controller_type" {}
+variable "deployment_controller_type" {
+}
 
 # deployment_maximum_percent sets the maximum size of the total capacity in tasks in % compared to the normal capacity at deployment
-variable "deployment_maximum_percent" {}
+variable "deployment_maximum_percent" {
+}
 
 # deployment_minimum_healthy_percent sets the minimum size of the total capacity in tasks in % compared to the normal capacity at deployment
-variable "deployment_minimum_healthy_percent" {}
+variable "deployment_minimum_healthy_percent" {
+}
 
 # awsvpc_subnets defines the subnets for the ECS Tasks to reside in case of AWSVPC
 variable "awsvpc_subnets" {
@@ -59,16 +72,19 @@ variable "lb_target_group_arn" {
 }
 
 # What kind of load balancing
-variable "load_balancing_type" {}
+variable "load_balancing_type" {
+}
 
 # Spread tasks over ECS Cluster based on AZ, Instance-id, memory
-variable "with_placement_strategy" {}
+variable "with_placement_strategy" {
+}
 
 # The amount of time to wait before the first health check. Only relevant for load balanced apps
-variable "health_check_grace_period_seconds" {}
+variable "health_check_grace_period_seconds" {
+}
 
 variable "tags" {
-  type    = "map"
+  type    = map(string)
   default = {}
 }
 
@@ -100,3 +116,4 @@ variable "service_discovery_routing_policy" {
 variable "service_discovery_healthcheck_custom_failure_threshold" {
   default = "1"
 }
+

--- a/modules/ecs_service/variables.tf
+++ b/modules/ecs_service/variables.tf
@@ -66,6 +66,11 @@ variable "awsvpc_security_group_ids" {
   default = []
 }
 
+# assign_public_ip is whether to assign a public IP address for AWSVPC
+variable "assign_public_ip" {
+  default = false
+}
+
 # lb_target_group_arn sets the arn of the target_group the service needs to connect to
 variable "lb_target_group_arn" {
   default = ""

--- a/modules/ecs_task_definition/main.tf
+++ b/modules/ecs_task_definition/main.tf
@@ -40,6 +40,8 @@ resource "aws_ecs_task_definition" "app" {
   # We need to ignore future container_definitions, and placement_constraints, as other tools take care of updating the task definition
 
   requires_compatibilities = [var.launch_type]
+
+  tags = var.tags
 }
 
 resource "aws_ecs_task_definition" "app_with_docker_volume" {
@@ -93,5 +95,7 @@ resource "aws_ecs_task_definition" "app_with_docker_volume" {
   network_mode = var.awsvpc_enabled ? "awsvpc" : "bridge"
 
   requires_compatibilities = [var.launch_type]
+
+  tags = var.tags
 }
 

--- a/modules/ecs_task_definition/main.tf
+++ b/modules/ecs_task_definition/main.tf
@@ -42,6 +42,10 @@ resource "aws_ecs_task_definition" "app" {
   requires_compatibilities = [var.launch_type]
 
   tags = var.tags
+
+  lifecycle {
+    create_before_destroy = true
+  }
 }
 
 resource "aws_ecs_task_definition" "app_with_docker_volume" {

--- a/modules/ecs_task_definition/main.tf
+++ b/modules/ecs_task_definition/main.tf
@@ -1,72 +1,97 @@
 locals {
-  docker_volume_name = "${lookup(var.docker_volume, "name", "")}"
+  docker_volume_name = lookup(var.docker_volume, "name", "")
 }
 
 resource "aws_ecs_task_definition" "app" {
-  count = "${(var.create && (local.docker_volume_name == "")) ? 1 : 0 }"
+  count = var.create && local.docker_volume_name == "" ? 1 : 0
 
-  family        = "${var.name}"
-  task_role_arn = "${var.ecs_taskrole_arn}"
+  family        = var.name
+  task_role_arn = var.ecs_taskrole_arn
 
   # Execution role ARN can be needed inside FARGATE
-  execution_role_arn = "${var.ecs_task_execution_role_arn}"
+  execution_role_arn = var.ecs_task_execution_role_arn
 
   # Used for Fargate
-  cpu    = "${var.cpu}"
-  memory = "${var.memory}"
+  cpu    = var.cpu
+  memory = var.memory
 
-  # This is a hack: https://github.com/hashicorp/terraform/issues/14037#issuecomment-361202716
-  # Specifically, we are assigning a list of maps to the `volume` block to
-  # mimic multiple `volume` statements
-  # This WILL break in Terraform 0.12: https://github.com/hashicorp/terraform/issues/14037#issuecomment-361358928
-  # but we need something that works before then
-  volume = ["${var.host_path_volumes}"]
+  dynamic "volume" {
+    for_each = var.host_path_volumes
+    content {
+      host_path = lookup(volume.value, "host_path", null)
+      name      = volume.value.name
 
-  container_definitions = "${var.container_definitions}"
-  network_mode          = "${var.awsvpc_enabled ? "awsvpc" : "bridge"}"
+      dynamic "docker_volume_configuration" {
+        for_each = lookup(volume.value, "docker_volume_configuration", [])
+        content {
+          autoprovision = lookup(docker_volume_configuration.value, "autoprovision", null)
+          driver        = lookup(docker_volume_configuration.value, "driver", null)
+          driver_opts   = lookup(docker_volume_configuration.value, "driver_opts", null)
+          labels        = lookup(docker_volume_configuration.value, "labels", null)
+          scope         = lookup(docker_volume_configuration.value, "scope", null)
+        }
+      }
+    }
+  }
+
+  container_definitions = var.container_definitions
+  network_mode          = var.awsvpc_enabled ? "awsvpc" : "bridge"
 
   # We need to ignore future container_definitions, and placement_constraints, as other tools take care of updating the task definition
 
-  requires_compatibilities = ["${var.launch_type}"]
+  requires_compatibilities = [var.launch_type]
 }
 
 resource "aws_ecs_task_definition" "app_with_docker_volume" {
-  count = "${(var.create && (local.docker_volume_name != "")) ? 1 : 0 }"
+  count = var.create && local.docker_volume_name != "" ? 1 : 0
 
-  family        = "${var.name}"
-  task_role_arn = "${var.ecs_taskrole_arn}"
+  family        = var.name
+  task_role_arn = var.ecs_taskrole_arn
 
   # Execution role ARN can be needed inside FARGATE
-  execution_role_arn = "${var.ecs_task_execution_role_arn}"
+  execution_role_arn = var.ecs_task_execution_role_arn
 
   # Used for Fargate
-  cpu    = "${var.cpu}"
-  memory = "${var.memory}"
+  cpu    = var.cpu
+  memory = var.memory
 
-  # This is a hack: https://github.com/hashicorp/terraform/issues/14037#issuecomment-361202716
-  # Specifically, we are assigning a list of maps to the `volume` block to
-  # mimic multiple `volume` statements
-  # This WILL break in Terraform 0.12: https://github.com/hashicorp/terraform/issues/14037#issuecomment-361358928
-  # but we need something that works before then
-  volume = ["${var.host_path_volumes}"]
+  dynamic "volume" {
+    for_each = var.host_path_volumes
+    content {
+      host_path = lookup(volume.value, "host_path", null)
+      name      = volume.value.name
+
+      dynamic "docker_volume_configuration" {
+        for_each = lookup(volume.value, "docker_volume_configuration", [])
+        content {
+          autoprovision = lookup(docker_volume_configuration.value, "autoprovision", null)
+          driver        = lookup(docker_volume_configuration.value, "driver", null)
+          driver_opts   = lookup(docker_volume_configuration.value, "driver_opts", null)
+          labels        = lookup(docker_volume_configuration.value, "labels", null)
+          scope         = lookup(docker_volume_configuration.value, "scope", null)
+        }
+      }
+    }
+  }
 
   # Unfortunately, the same hack doesn't work for a list of Docker volume
   # blocks because they include a nested map; therefore the only way to
   # currently sanely support Docker volume blocks is to only consider the
   # single volume case.
-  volume = {
-    name = "${local.docker_volume_name}"
+  volume {
+    name = local.docker_volume_name
 
     docker_volume_configuration {
-      autoprovision = "${lookup(var.docker_volume, "autoprovision", false)}"
-      scope         = "${lookup(var.docker_volume, "scope", "shared")}"
-      driver        = "${lookup(var.docker_volume, "driver", "")}"
+      autoprovision = lookup(var.docker_volume, "autoprovision", false)
+      scope         = lookup(var.docker_volume, "scope", "shared")
+      driver        = lookup(var.docker_volume, "driver", "")
     }
   }
 
-  container_definitions = "${var.container_definitions}"
+  container_definitions = var.container_definitions
 
-  network_mode = "${var.awsvpc_enabled ? "awsvpc" : "bridge"}"
+  network_mode = var.awsvpc_enabled ? "awsvpc" : "bridge"
 
-  requires_compatibilities = ["${var.launch_type}"]
+  requires_compatibilities = [var.launch_type]
 }
+

--- a/modules/ecs_task_definition/output.tf
+++ b/modules/ecs_task_definition/output.tf
@@ -1,12 +1,34 @@
 # The arn of the task definition
 output "aws_ecs_task_definition_arn" {
-  value = "${element(concat(aws_ecs_task_definition.app.*.arn, aws_ecs_task_definition.app_with_docker_volume.*.arn, list("")), 0)}"
+  value = element(
+    concat(
+      aws_ecs_task_definition.app.*.arn,
+      aws_ecs_task_definition.app_with_docker_volume.*.arn,
+      [""],
+    ),
+    0,
+  )
 }
 
 output "aws_ecs_task_definition_family" {
-  value = "${element(concat(aws_ecs_task_definition.app.*.family, aws_ecs_task_definition.app_with_docker_volume.*.family, list("")), 0)}"
+  value = element(
+    concat(
+      aws_ecs_task_definition.app.*.family,
+      aws_ecs_task_definition.app_with_docker_volume.*.family,
+      [""],
+    ),
+    0,
+  )
 }
 
 output "aws_ecs_task_definition_revision" {
-  value = "${element(concat(aws_ecs_task_definition.app.*.revision, aws_ecs_task_definition.app_with_docker_volume.*.revision, list("")), 0)}"
+  value = element(
+    concat(
+      aws_ecs_task_definition.app.*.revision,
+      aws_ecs_task_definition.app_with_docker_volume.*.revision,
+      [""],
+    ),
+    0,
+  )
 }
+

--- a/modules/ecs_task_definition/output.tf
+++ b/modules/ecs_task_definition/output.tf
@@ -1,34 +1,19 @@
 # The arn of the task definition
 output "aws_ecs_task_definition_arn" {
-  value = element(
-    concat(
-      aws_ecs_task_definition.app.*.arn,
-      aws_ecs_task_definition.app_with_docker_volume.*.arn,
-      [""],
-    ),
-    0,
-  )
+  value = try(aws_ecs_task_definition.app.0.arn,
+    aws_ecs_task_definition.app_with_docker_volume.0.arn,
+    "")
 }
 
 output "aws_ecs_task_definition_family" {
-  value = element(
-    concat(
-      aws_ecs_task_definition.app.*.family,
-      aws_ecs_task_definition.app_with_docker_volume.*.family,
-      [""],
-    ),
-    0,
-  )
+  value = try(aws_ecs_task_definition.app.0.family,
+    aws_ecs_task_definition.app_with_docker_volume.0.family,
+    "")
 }
 
 output "aws_ecs_task_definition_revision" {
-  value = element(
-    concat(
-      aws_ecs_task_definition.app.*.revision,
-      aws_ecs_task_definition.app_with_docker_volume.*.revision,
-      [""],
-    ),
-    0,
-  )
+  value = try(aws_ecs_task_definition.app.0.revision,
+    aws_ecs_task_definition.app_with_docker_volume.0.revision,
+    "")
 }
 

--- a/modules/ecs_task_definition/variables.tf
+++ b/modules/ecs_task_definition/variables.tf
@@ -89,3 +89,8 @@ variable "mountpoints" {
   # },
 }
 
+variable "tags" {
+  description = "A map of tags to apply to all taggable resources"
+  type        = map(string)
+  default     = {}
+}

--- a/modules/ecs_task_definition/variables.tf
+++ b/modules/ecs_task_definition/variables.tf
@@ -1,5 +1,6 @@
 # name of the ecs_service
-variable "name" {}
+variable "name" {
+}
 
 # create
 variable "create" {
@@ -7,7 +8,8 @@ variable "create" {
 }
 
 # cluster name
-variable "cluster_name" {}
+variable "cluster_name" {
+}
 
 # is awsvpc enabled ?
 variable "awsvpc_enabled" {
@@ -20,33 +22,39 @@ variable "fargate_enabled" {
 }
 
 # container_definitions set the json with the container definitions
-variable "container_definitions" {}
+variable "container_definitions" {
+}
 
 # cpu is set in case Fargate is used
 # https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-cpu-memory-error.html
-variable "cpu" {}
+variable "cpu" {
+}
 
 # memory is set in case Fargate is used
 # https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-cpu-memory-error.html
-variable "memory" {}
+variable "memory" {
+}
 
 # ecs_taskrole_arn sets the arn of the ECS Task role
-variable "ecs_taskrole_arn" {}
+variable "ecs_taskrole_arn" {
+}
 
 # ecs_task_execution_role_arn sets the execution role arn, needed for FARGATE
-variable "ecs_task_execution_role_arn" {}
+variable "ecs_task_execution_role_arn" {
+}
 
 # AWS Region
-variable "region" {}
+variable "region" {
+}
 
 # launch_type sets the launch_type, either EC2 or FARGATE
-variable "launch_type" {}
+variable "launch_type" {
+}
 
 # A Docker volume to add to the task
 variable "docker_volume" {
-  type    = "map"
+  type    = map(string)
   default = {}
-
   # {
   # # these properties are supported as a 'flattened' version of the docker volume configuration:
   # # https://www.terraform.io/docs/providers/aws/r/ecs_task_definition.html#docker_volume_configuration
@@ -62,9 +70,8 @@ variable "docker_volume" {
 
 # list of host paths to add as volumes to the task
 variable "host_path_volumes" {
-  type    = "list"
+  type    = list(map(string))
   default = []
-
   # {
   #     name = "service-storage",
   #     host_path = "/foo"
@@ -73,12 +80,12 @@ variable "host_path_volumes" {
 
 # list of mount points to add to every container in the task
 variable "mountpoints" {
-  type    = "list"
+  type    = list(map(string))
   default = []
-
   # {
   #     source_volume = "service-storage",
   #     container_path = "/foo",
   #     read_only = "false"
   # },
 }
+

--- a/modules/ecs_task_definition_selector/main.tf
+++ b/modules/ecs_task_definition_selector/main.tf
@@ -1,6 +1,6 @@
 # This is the terraform task definition
 data "aws_ecs_container_definition" "current" {
-  count           = var.create ? 1 : 0
+  count           = var.create && var.aws_ecs_task_definition_family != "" ? 1 : 0
   task_definition = "${var.aws_ecs_task_definition_family}:${var.aws_ecs_task_definition_revision}"
   container_name  = var.ecs_container_name
 }

--- a/modules/ecs_task_definition_selector/main.tf
+++ b/modules/ecs_task_definition_selector/main.tf
@@ -1,33 +1,39 @@
 # This is the terraform task definition
 data "aws_ecs_container_definition" "current" {
-  count           = "${var.create ? 1 : 0 }"
+  count           = var.create ? 1 : 0
   task_definition = "${var.aws_ecs_task_definition_family}:${var.aws_ecs_task_definition_revision}"
-  container_name  = "${var.ecs_container_name}"
+  container_name  = var.ecs_container_name
 }
 
 locals {
   # Calculate if there is an actual change between the current terraform task definition in the state
   # and the current live one
-  image = "${concat(list(),data.aws_ecs_container_definition.current.*.image, list(""))}"
+  image = concat([], data.aws_ecs_container_definition.current.*.image, [""])
 
-  cpu                = "${concat(list(),data.aws_ecs_container_definition.current.*.cpu, list(""))}"
-  memory             = "${concat(list(),data.aws_ecs_container_definition.current.*.memory, list(""))}"
-  memory_reservation = "${concat(list(),data.aws_ecs_container_definition.current.*.memory_reservation, list(""))}"
-  docker_labels      = "${concat(list(),data.aws_ecs_container_definition.current.*.docker_labels, list(map()))}"
-  environment        = "${concat(data.aws_ecs_container_definition.current.*.environment, list(map()))}"
+  cpu    = concat([], data.aws_ecs_container_definition.current.*.cpu, [""])
+  memory = concat([], data.aws_ecs_container_definition.current.*.memory, [""])
+  memory_reservation = concat(
+    [],
+    data.aws_ecs_container_definition.current.*.memory_reservation,
+    [""],
+  )
+  docker_labels = concat(
+    [],
+    data.aws_ecs_container_definition.current.*.docker_labels,
+    [{}],
+  )
+  environment = concat(
+    data.aws_ecs_container_definition.current.*.environment,
+    [{}],
+  )
 
-  has_changed = "${ local.image[0] != var.live_aws_ecs_task_definition_image ||
-                   local.cpu[0] != var.live_aws_ecs_task_definition_cpu ||
-                   local.memory[0] != var.live_aws_ecs_task_definition_memory ||
-                   local.memory_reservation[0] != "${var.live_aws_ecs_task_definition_memory_reservation == "undefined" ? "0" : var.live_aws_ecs_task_definition_memory_reservation}" ||
-                   lookup(local.docker_labels[0],"_airship_dockerlabel_hash","") != var.live_aws_ecs_task_definition_docker_label_hash ||
-                   lookup(local.docker_labels[0],"_airship_secrets_hash","") != var.live_aws_ecs_task_definition_secrets_hash ||
-                   jsonencode(local.environment[0]) != var.live_aws_ecs_task_definition_environment_json }"
+  has_changed = local.image[0] != var.live_aws_ecs_task_definition_image || local.cpu[0] != var.live_aws_ecs_task_definition_cpu || local.memory[0] != var.live_aws_ecs_task_definition_memory || local.memory_reservation[0] != (var.live_aws_ecs_task_definition_memory_reservation == "undefined" ? "0" : var.live_aws_ecs_task_definition_memory_reservation) || lookup(local.docker_labels[0], "_airship_dockerlabel_hash", "") != var.live_aws_ecs_task_definition_docker_label_hash || lookup(local.docker_labels[0], "_airship_secrets_hash", "") != var.live_aws_ecs_task_definition_secrets_hash || jsonencode(local.environment[0]) != var.live_aws_ecs_task_definition_environment_json
 
   # If there is a difference, between the ( newly created) terraform state task definition and the live task definition
   # select the current task definition for deployment
   # Otherwise, keep using the current live task definition
 
-  revision        = "${local.has_changed ? var.aws_ecs_task_definition_revision : var.live_aws_ecs_task_definition_revision}"
+  revision        = local.has_changed ? var.aws_ecs_task_definition_revision : var.live_aws_ecs_task_definition_revision
   task_definition = "${var.aws_ecs_task_definition_family}:${local.revision}"
 }
+

--- a/modules/ecs_task_definition_selector/outputs.tf
+++ b/modules/ecs_task_definition_selector/outputs.tf
@@ -1,16 +1,41 @@
 output "selected_task_definition_for_deployment" {
-  value = "${local.task_definition}"
+  value = local.task_definition
 }
 
 output "has_changed" {
-  value = "${
-    format("\n%v\n%v\n%v\n%v\n%v\n%v\n%v\n",
-    format("Image: %v | %v", local.image[0], var.live_aws_ecs_task_definition_image),
-    format("CPU: %v | %v", local.cpu[0], var.live_aws_ecs_task_definition_cpu),
-    format("Memory: %v | %v", local.memory[0], var.live_aws_ecs_task_definition_memory),
-    format("Memory Reservation: %v | %v", local.memory_reservation[0], "${var.live_aws_ecs_task_definition_memory_reservation == "undefined" ? "0" : var.live_aws_ecs_task_definition_memory_reservation}"),
-    format("Docker Labels: %v | %v", lookup(local.docker_labels[0],"_airship_dockerlabel_hash",""), var.live_aws_ecs_task_definition_docker_label_hash),
-    format("Environment: %v | %v", jsonencode(local.environment[0]) , var.live_aws_ecs_task_definition_environment_json),
-    format("Has_changed: %v", local.has_changed))
-    }"
+  value = format(
+    "\n%v\n%v\n%v\n%v\n%v\n%v\n%v\n",
+    format(
+      "Image: %v | %v",
+      local.image[0],
+      var.live_aws_ecs_task_definition_image,
+    ),
+    format(
+      "CPU: %v | %v",
+      local.cpu[0],
+      var.live_aws_ecs_task_definition_cpu,
+    ),
+    format(
+      "Memory: %v | %v",
+      local.memory[0],
+      var.live_aws_ecs_task_definition_memory,
+    ),
+    format(
+      "Memory Reservation: %v | %v",
+      local.memory_reservation[0],
+      var.live_aws_ecs_task_definition_memory_reservation == "undefined" ? "0" : var.live_aws_ecs_task_definition_memory_reservation,
+    ),
+    format(
+      "Docker Labels: %v | %v",
+      lookup(local.docker_labels[0], "_airship_dockerlabel_hash", ""),
+      var.live_aws_ecs_task_definition_docker_label_hash,
+    ),
+    format(
+      "Environment: %v | %v",
+      jsonencode(local.environment[0]),
+      var.live_aws_ecs_task_definition_environment_json,
+    ),
+    format("Has_changed: %v", local.has_changed),
+  )
 }
+

--- a/modules/ecs_task_definition_selector/variables.tf
+++ b/modules/ecs_task_definition_selector/variables.tf
@@ -2,20 +2,40 @@ variable "create" {
   default = true
 }
 
-variable "ecs_container_name" {}
+variable "ecs_container_name" {
+}
 
 # Reflecting the current state
 
-variable "aws_ecs_task_definition_family" {}
-variable "aws_ecs_task_definition_revision" {}
+variable "aws_ecs_task_definition_family" {
+}
+
+variable "aws_ecs_task_definition_revision" {
+}
 
 # Reflecting the live state independent of the Terraform state
 
-variable "live_aws_ecs_task_definition_revision" {}
-variable "live_aws_ecs_task_definition_image" {}
-variable "live_aws_ecs_task_definition_cpu" {}
-variable "live_aws_ecs_task_definition_memory" {}
-variable "live_aws_ecs_task_definition_memory_reservation" {}
-variable "live_aws_ecs_task_definition_environment_json" {}
-variable "live_aws_ecs_task_definition_docker_label_hash" {}
-variable "live_aws_ecs_task_definition_secrets_hash" {}
+variable "live_aws_ecs_task_definition_revision" {
+}
+
+variable "live_aws_ecs_task_definition_image" {
+}
+
+variable "live_aws_ecs_task_definition_cpu" {
+}
+
+variable "live_aws_ecs_task_definition_memory" {
+}
+
+variable "live_aws_ecs_task_definition_memory_reservation" {
+}
+
+variable "live_aws_ecs_task_definition_environment_json" {
+}
+
+variable "live_aws_ecs_task_definition_docker_label_hash" {
+}
+
+variable "live_aws_ecs_task_definition_secrets_hash" {
+}
+

--- a/modules/iam/main.tf
+++ b/modules/iam/main.tf
@@ -1,17 +1,17 @@
 # We need the AWS Account ID for the SSM Permissions
 data "aws_caller_identity" "current" {
-  count = "${var.create ? 1 : 0 }"
+  count = var.create ? 1 : 0
 }
 
 # Assume Role Policy for the ECS Task
 data "aws_iam_policy_document" "ecs_task_assume_role" {
-  count = "${var.create ? 1 : 0 }"
+  count = var.create ? 1 : 0
 
   statement {
     effect  = "Allow"
     actions = ["sts:AssumeRole"]
 
-    principals = {
+    principals {
       type        = "Service"
       identifiers = ["ecs-tasks.amazonaws.com"]
     }
@@ -20,47 +20,47 @@ data "aws_iam_policy_document" "ecs_task_assume_role" {
 
 # The ECS TASK ROLE execution role needed for FARGATE & AWS LOGS
 resource "aws_iam_role" "ecs_task_execution_role" {
-  count              = "${(var.create && (var.fargate_enabled || var.container_secrets_enabled) ) ? 1 : 0 }"
+  count              = var.create && var.fargate_enabled || var.container_secrets_enabled ? 1 : 0
   name               = "${var.name}-ecs-task-execution_role"
-  assume_role_policy = "${data.aws_iam_policy_document.ecs_task_assume_role.json}"
+  assume_role_policy = data.aws_iam_policy_document.ecs_task_assume_role[0].json
 }
 
 # We need this for tasks with an execution role, e.g. those using Fargate or SSM secrets
 resource "aws_iam_role_policy_attachment" "ecs_tasks_execution_role" {
-  count      = "${(var.create && (var.fargate_enabled || var.container_secrets_enabled) ) ? 1 : 0 }"
-  role       = "${aws_iam_role.ecs_task_execution_role.id}"
+  count      = var.create && var.fargate_enabled || var.container_secrets_enabled ? 1 : 0
+  role       = aws_iam_role.ecs_task_execution_role[0].id
   policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"
 }
 
 # The actual ECS TASK ROLE
 resource "aws_iam_role" "ecs_tasks_role" {
-  count              = "${var.create ? 1 : 0 }"
+  count              = var.create ? 1 : 0
   name               = "${var.name}-task-role"
-  assume_role_policy = "${data.aws_iam_policy_document.ecs_task_assume_role.json}"
+  assume_role_policy = data.aws_iam_policy_document.ecs_task_assume_role[0].json
 }
 
 # Policy Document to allow KMS Decryption with given keys
 data "aws_iam_policy_document" "kms_permissions" {
-  count = "${var.create && var.kms_enabled? 1 : 0 }"
+  count = var.create && var.kms_enabled ? 1 : 0
 
   statement {
     effect    = "Allow"
     actions   = ["kms:Decrypt"]
-    resources = ["${var.kms_keys}"]
+    resources = var.kms_keys
   }
 }
 
 # Allow KMS-Decrypt permissions for the ECS Task Role
 resource "aws_iam_role_policy" "kms_permissions" {
-  count  = "${(var.create && var.kms_enabled) ? 1 : 0 }"
+  count  = var.create && var.kms_enabled ? 1 : 0
   name   = "${var.name}-kms-permissions"
-  role   = "${aws_iam_role.ecs_tasks_role.id}"
-  policy = "${data.aws_iam_policy_document.kms_permissions.json}"
+  role   = aws_iam_role.ecs_tasks_role[0].id
+  policy = data.aws_iam_policy_document.kms_permissions[0].json
 }
 
 # Policy Document to allow access to SSM Parameter Store paths
 data "aws_iam_policy_document" "ssm_permissions" {
-  count = "${var.create && (var.ssm_enabled || var.container_secrets_enabled) ? 1 : 0 }"
+  count = var.create && var.ssm_enabled || var.container_secrets_enabled ? 1 : 0
 
   ## Add Describe Parameters as per https://docs.aws.amazon.com/systems-manager/latest/userguide/sysman-paramstore-access.html
   statement {
@@ -71,83 +71,89 @@ data "aws_iam_policy_document" "ssm_permissions" {
 
   ## With the custom application prefix for ssm
   statement {
-    effect    = "Allow"
-    actions   = ["ssm:GetParameter", "ssm:GetParametersByPath", "ssm:GetParameters"]
-    resources = ["${formatlist("arn:aws:ssm:${var.region}:${data.aws_caller_identity.current.account_id}:parameter/application/%s/*",var.ssm_paths)}"]
+    effect  = "Allow"
+    actions = ["ssm:GetParameter", "ssm:GetParametersByPath", "ssm:GetParameters"]
+    resources = formatlist(
+      "arn:aws:ssm:${var.region}:${data.aws_caller_identity.current[0].account_id}:parameter/application/%s/*",
+      var.ssm_paths,
+    )
   }
 
   ## And also without the application prefix
   statement {
-    effect    = "Allow"
-    actions   = ["ssm:GetParameter", "ssm:GetParametersByPath", "ssm:GetParameters"]
-    resources = ["${formatlist("arn:aws:ssm:${var.region}:${data.aws_caller_identity.current.account_id}:parameter/%s/*",var.ssm_paths)}"]
+    effect  = "Allow"
+    actions = ["ssm:GetParameter", "ssm:GetParametersByPath", "ssm:GetParameters"]
+    resources = formatlist(
+      "arn:aws:ssm:${var.region}:${data.aws_caller_identity.current[0].account_id}:parameter/%s/*",
+      var.ssm_paths,
+    )
   }
 }
 
 # Add the SSM policy to the task role
 resource "aws_iam_role_policy" "ssm_permissions" {
-  count  = "${(var.create && var.ssm_enabled) ? 1 : 0 }"
+  count  = var.create && var.ssm_enabled ? 1 : 0
   name   = "${var.name}-ssm-permissions"
-  role   = "${aws_iam_role.ecs_tasks_role.id}"
-  policy = "${data.aws_iam_policy_document.ssm_permissions.json}"
+  role   = aws_iam_role.ecs_tasks_role[0].id
+  policy = data.aws_iam_policy_document.ssm_permissions[0].json
 }
 
 # Add the SSM policy to the task execution role
 resource "aws_iam_role_policy" "ssm_permissions_execution" {
-  count  = "${(var.create && var.container_secrets_enabled) ? 1 : 0 }"
+  count  = var.create && var.container_secrets_enabled ? 1 : 0
   name   = "${var.name}-ssm-permissions-execution-role"
-  role   = "${aws_iam_role.ecs_task_execution_role.id}"
-  policy = "${data.aws_iam_policy_document.ssm_permissions.json}"
+  role   = aws_iam_role.ecs_task_execution_role[0].id
+  policy = data.aws_iam_policy_document.ssm_permissions[0].json
 }
 
 # Policy Document to allow S3 Read-Write Access to given paths
 data "aws_iam_policy_document" "s3_rw_permissions" {
-  count = "${var.create ? 1 : 0 }"
+  count = var.create ? 1 : 0
 
   statement {
     effect    = "Allow"
     actions   = ["s3:ListBucket"]
-    resources = ["${formatlist("arn:aws:s3:::%s",var.s3_rw_paths)}"]
+    resources = formatlist("arn:aws:s3:::%s", var.s3_rw_paths)
   }
 
   statement {
     effect    = "Allow"
     actions   = ["s3:*"]
-    resources = ["${formatlist("arn:aws:s3:::%s/*",var.s3_rw_paths)}"]
+    resources = formatlist("arn:aws:s3:::%s/*", var.s3_rw_paths)
   }
 }
 
 # Policy Document to allow S3 Read-Only Access to given paths
 data "aws_iam_policy_document" "s3_ro_permissions" {
-  count = "${var.create ? 1 : 0 }"
+  count = var.create ? 1 : 0
 
   statement {
     effect    = "Allow"
     actions   = ["s3:ListBucket"]
-    resources = ["${formatlist("arn:aws:s3:::%s",var.s3_ro_paths)}"]
+    resources = formatlist("arn:aws:s3:::%s", var.s3_ro_paths)
   }
 
   statement {
     effect    = "Allow"
     actions   = ["s3:GetObject"]
-    resources = ["${formatlist("arn:aws:s3:::%s/*",var.s3_ro_paths)}"]
+    resources = formatlist("arn:aws:s3:::%s/*", var.s3_ro_paths)
   }
 }
 
 # Add the S3 Read-Write policy to the task role
 resource "aws_iam_role_policy" "s3_rw_permissions" {
   name   = "s3-read-write-policy"
-  count  = "${(var.create && length(var.s3_rw_paths) > 0 ) ? 1 : 0 }"
-  role   = "${aws_iam_role.ecs_tasks_role.id}"
-  policy = "${data.aws_iam_policy_document.s3_rw_permissions.json}"
+  count  = var.create && length(var.s3_rw_paths) > 0 ? 1 : 0
+  role   = aws_iam_role.ecs_tasks_role[0].id
+  policy = data.aws_iam_policy_document.s3_rw_permissions[0].json
 }
 
 # Add the S3 Read-Only policy to the task role
 resource "aws_iam_role_policy" "s3_ro_permissions" {
-  count  = "${(var.create && length(var.s3_ro_paths) > 0 ) ? 1 : 0 }"
+  count  = var.create && length(var.s3_ro_paths) > 0 ? 1 : 0
   name   = "s3-readonly-policy"
-  role   = "${aws_iam_role.ecs_tasks_role.id}"
-  policy = "${data.aws_iam_policy_document.s3_ro_permissions.json}"
+  role   = aws_iam_role.ecs_tasks_role[0].id
+  policy = data.aws_iam_policy_document.s3_ro_permissions[0].json
 }
 
 ### Lambdas
@@ -168,7 +174,7 @@ data "aws_iam_policy_document" "lambda_trust_policy" {
 
 # Policy for the ecs lookup lambda
 data "aws_iam_policy_document" "lambda_lookup_policy" {
-  count = "${var.create ? 1 : 0 }"
+  count = var.create ? 1 : 0
 
   statement {
     effect = "Allow"
@@ -193,7 +199,12 @@ data "aws_iam_policy_document" "lambda_lookup_policy" {
     ]
 
     resources = [
-      "${format("arn:aws:logs:%s:%s:log-group:/aws/lambda/%s-lambda-lookup:*",var.region, join("",data.aws_caller_identity.current.*.account_id), var.name)}",
+      format(
+        "arn:aws:logs:%s:%s:log-group:/aws/lambda/%s-lambda-lookup:*",
+        var.region,
+        join("", data.aws_caller_identity.current.*.account_id),
+        var.name,
+      ),
     ]
 
     effect = "Allow"
@@ -203,7 +214,12 @@ data "aws_iam_policy_document" "lambda_lookup_policy" {
     actions = ["logs:PutLogEvents"]
 
     resources = [
-      "${format("arn:aws:logs:%s:%s:log-group:/aws/lambda/%s-lambda-lookup:*.*",var.region, join("",data.aws_caller_identity.current.*.account_id), var.name)}",
+      format(
+        "arn:aws:logs:%s:%s:log-group:/aws/lambda/%s-lambda-lookup:*.*",
+        var.region,
+        join("", data.aws_caller_identity.current.*.account_id),
+        var.name,
+      ),
     ]
 
     effect = "Allow"
@@ -212,21 +228,21 @@ data "aws_iam_policy_document" "lambda_lookup_policy" {
 
 # Role for lambda to lookup the ecs cluster & services
 resource "aws_iam_role" "lambda_lookup" {
-  count              = "${var.create ? 1 : 0 }"
+  count              = var.create ? 1 : 0
   name               = "ecs-lambda-lookup-${var.name}"
   description        = "Role permitting Lambda functions to be invoked from Lambda"
-  assume_role_policy = "${data.aws_iam_policy_document.lambda_trust_policy.0.json}"
+  assume_role_policy = data.aws_iam_policy_document.lambda_trust_policy.json
 }
 
 resource "aws_iam_role_policy" "lambda_lookup_policy" {
-  count  = "${var.create ? 1 : 0 }"
-  role   = "${aws_iam_role.lambda_lookup.name}"
-  policy = "${data.aws_iam_policy_document.lambda_lookup_policy.0.json}"
+  count  = var.create ? 1 : 0
+  role   = aws_iam_role.lambda_lookup[0].name
+  policy = data.aws_iam_policy_document.lambda_lookup_policy[0].json
 }
 
 # Policy for the Lambda Logging & ECS
 data "aws_iam_policy_document" "lambda_ecs_task_scheduler_policy" {
-  count = "${var.create ? 1 : 0 }"
+  count = var.create ? 1 : 0
 
   statement {
     actions = [
@@ -273,7 +289,12 @@ data "aws_iam_policy_document" "lambda_ecs_task_scheduler_policy" {
     ]
 
     resources = [
-      "${format("arn:aws:logs:%s:%s:log-group:/aws/lambda/%s-task-scheduler:*",var.region, join("",data.aws_caller_identity.current.*.account_id), var.name)}",
+      format(
+        "arn:aws:logs:%s:%s:log-group:/aws/lambda/%s-task-scheduler:*",
+        var.region,
+        join("", data.aws_caller_identity.current.*.account_id),
+        var.name,
+      ),
     ]
 
     effect = "Allow"
@@ -283,7 +304,12 @@ data "aws_iam_policy_document" "lambda_ecs_task_scheduler_policy" {
     actions = ["logs:PutLogEvents"]
 
     resources = [
-      "${format("arn:aws:logs:%s:%s:log-group:/aws/lambda/%s-task-scheduler:*.*",var.region, join("",data.aws_caller_identity.current.*.account_id), var.name)}",
+      format(
+        "arn:aws:logs:%s:%s:log-group:/aws/lambda/%s-task-scheduler:*.*",
+        var.region,
+        join("", data.aws_caller_identity.current.*.account_id),
+        var.name,
+      ),
     ]
 
     effect = "Allow"
@@ -292,26 +318,26 @@ data "aws_iam_policy_document" "lambda_ecs_task_scheduler_policy" {
 
 # Role for the lambda
 resource "aws_iam_role" "lambda_ecs_task_scheduler" {
-  count              = "${var.create ? 1 : 0}"
+  count              = var.create ? 1 : 0
   name               = "ecs-lambda-task-scheduler-${var.name}"
-  assume_role_policy = "${data.aws_iam_policy_document.lambda_trust_policy.0.json}"
+  assume_role_policy = data.aws_iam_policy_document.lambda_trust_policy.json
 }
 
 resource "aws_iam_role_policy" "lambda_ecs_task_scheduler_policy" {
-  count  = "${var.create ? 1 : 0 }"
-  role   = "${aws_iam_role.lambda_ecs_task_scheduler.name}"
-  policy = "${data.aws_iam_policy_document.lambda_ecs_task_scheduler_policy.0.json}"
+  count  = var.create ? 1 : 0
+  role   = aws_iam_role.lambda_ecs_task_scheduler[0].name
+  policy = data.aws_iam_policy_document.lambda_ecs_task_scheduler_policy[0].json
 }
 
 # Role for ECS scheduled task
 data "aws_iam_policy_document" "scheduled-task-cloudwatch-assume-role-policy" {
-  count = "${var.create ? 1 : 0 }"
+  count = var.create ? 1 : 0
 
   statement {
     effect  = "Allow"
     actions = ["sts:AssumeRole"]
 
-    principals = {
+    principals {
       type        = "Service"
       identifiers = ["events.amazonaws.com"]
     }
@@ -319,7 +345,7 @@ data "aws_iam_policy_document" "scheduled-task-cloudwatch-assume-role-policy" {
 }
 
 data "aws_iam_policy_document" "scheduled_task_cloudwatch_policy" {
-  count = "${var.create ? 1 : 0 }"
+  count = var.create ? 1 : 0
 
   statement {
     effect    = "Allow"
@@ -337,14 +363,15 @@ data "aws_iam_policy_document" "scheduled_task_cloudwatch_policy" {
 }
 
 resource "aws_iam_role" "scheduled_task_cloudwatch" {
-  count              = "${var.create && var.is_scheduled_task ? 1 : 0 }"
+  count              = var.create && var.is_scheduled_task ? 1 : 0
   name               = "cloudwatch_ecs_task-${var.name}"
-  assume_role_policy = "${data.aws_iam_policy_document.scheduled-task-cloudwatch-assume-role-policy.json}"
+  assume_role_policy = data.aws_iam_policy_document.scheduled-task-cloudwatch-assume-role-policy[0].json
 }
 
 resource "aws_iam_role_policy" "scheduled_task_cloudwatch_policy" {
-  count  = "${var.create && var.is_scheduled_task ? 1 : 0 }"
+  count  = var.create && var.is_scheduled_task ? 1 : 0
   name   = "${var.name}-scheduled-task-policy"
-  role   = "${aws_iam_role.scheduled_task_cloudwatch.id}"
-  policy = "${data.aws_iam_policy_document.scheduled_task_cloudwatch_policy.json}"
+  role   = aws_iam_role.scheduled_task_cloudwatch[0].id
+  policy = data.aws_iam_policy_document.scheduled_task_cloudwatch_policy[0].json
 }
+

--- a/modules/iam/main.tf
+++ b/modules/iam/main.tf
@@ -106,6 +106,24 @@ resource "aws_iam_role_policy" "ssm_permissions_execution" {
   policy = data.aws_iam_policy_document.ssm_permissions[0].json
 }
 
+# Policy document allowing access to the repository credentials secret
+data "aws_iam_policy_document" "sm_secrets" {
+  count = signum(length(var.secretsmanager_secret_arns))
+
+  statement {
+    effect    = "Allow"
+    actions   = ["secretsmanager:GetSecretValue"]
+    resources = [for arn in var.secretsmanager_secret_arns: "${arn}-??????"]
+  }
+}
+
+resource "aws_iam_role_policy" "sm_secrets" {
+  count  = signum(length(var.secretsmanager_secret_arns))
+  name   = "${var.name}-secretsmanager-permissions"
+  role   = aws_iam_role.ecs_task_execution_role[0].id
+  policy = data.aws_iam_policy_document.sm_secrets[0].json
+}
+
 # Policy Document to allow S3 Read-Write Access to given paths
 data "aws_iam_policy_document" "s3_rw_permissions" {
   count = var.create ? 1 : 0

--- a/modules/iam/main.tf
+++ b/modules/iam/main.tf
@@ -361,14 +361,14 @@ data "aws_iam_policy_document" "lambda_ecs_task_scheduler_policy" {
 
 # Role for the lambda
 resource "aws_iam_role" "lambda_ecs_task_scheduler" {
-  count              = var.create ? 1 : 0
+  count              = var.create && var.task_scheduler_enabled ? 1 : 0
   name               = "ecs-lambda-task-scheduler-${var.name}"
   assume_role_policy = data.aws_iam_policy_document.lambda_trust_policy.json
   tags               = var.tags
 }
 
 resource "aws_iam_role_policy" "lambda_ecs_task_scheduler_policy" {
-  count  = var.create ? 1 : 0
+  count  = var.create && var.task_scheduler_enabled ? 1 : 0
   role   = aws_iam_role.lambda_ecs_task_scheduler[0].name
   policy = data.aws_iam_policy_document.lambda_ecs_task_scheduler_policy[0].json
 }

--- a/modules/iam/main.tf
+++ b/modules/iam/main.tf
@@ -23,6 +23,7 @@ resource "aws_iam_role" "ecs_task_execution_role" {
   count              = var.create && var.fargate_enabled || var.container_secrets_enabled ? 1 : 0
   name               = "${var.name}-ecs-task-execution_role"
   assume_role_policy = data.aws_iam_policy_document.ecs_task_assume_role[0].json
+  tags               = var.tags
 }
 
 # We need this for tasks with an execution role, e.g. those using Fargate or SSM secrets
@@ -37,6 +38,7 @@ resource "aws_iam_role" "ecs_tasks_role" {
   count              = var.create ? 1 : 0
   name               = "${var.name}-task-role"
   assume_role_policy = data.aws_iam_policy_document.ecs_task_assume_role[0].json
+  tags               = var.tags
 }
 
 # Policy Document to allow KMS Decryption with given keys
@@ -250,6 +252,7 @@ resource "aws_iam_role" "lambda_lookup" {
   name               = "ecs-lambda-lookup-${var.name}"
   description        = "Role permitting Lambda functions to be invoked from Lambda"
   assume_role_policy = data.aws_iam_policy_document.lambda_trust_policy.json
+  tags = var.tags
 }
 
 resource "aws_iam_role_policy" "lambda_lookup_policy" {
@@ -339,6 +342,7 @@ resource "aws_iam_role" "lambda_ecs_task_scheduler" {
   count              = var.create ? 1 : 0
   name               = "ecs-lambda-task-scheduler-${var.name}"
   assume_role_policy = data.aws_iam_policy_document.lambda_trust_policy.json
+  tags               = var.tags
 }
 
 resource "aws_iam_role_policy" "lambda_ecs_task_scheduler_policy" {
@@ -384,6 +388,7 @@ resource "aws_iam_role" "scheduled_task_cloudwatch" {
   count              = var.create && var.is_scheduled_task ? 1 : 0
   name               = "cloudwatch_ecs_task-${var.name}"
   assume_role_policy = data.aws_iam_policy_document.scheduled-task-cloudwatch-assume-role-policy[0].json
+  tags               = var.tags
 }
 
 resource "aws_iam_role_policy" "scheduled_task_cloudwatch_policy" {

--- a/modules/iam/output.tf
+++ b/modules/iam/output.tf
@@ -1,44 +1,54 @@
 output "ecs_task_execution_role_arn" {
   description = "ecs_task_execution_role_arn outputs the Role-Arn for the ECS Task Execution role."
-  value       = "${element(concat(aws_iam_role.ecs_task_execution_role.*.arn, list("")), 0)}"
+  value       = element(concat(aws_iam_role.ecs_task_execution_role.*.arn, [""]), 0)
 }
 
 output "ecs_task_execution_role_name" {
   description = "ecs_task_execution_role_arn outputs the Role-name for the ECS Task Execution role."
-  value       = "${element(concat(aws_iam_role.ecs_task_execution_role.*.name, list("")), 0)}"
+  value       = element(concat(aws_iam_role.ecs_task_execution_role.*.name, [""]), 0)
 }
 
 output "ecs_taskrole_arn" {
   description = "ecs_taskrole_arn outputs the Role-Arn of the ECS Task"
-  value       = "${element(concat(aws_iam_role.ecs_tasks_role.*.arn, list("")), 0)}"
+  value       = element(concat(aws_iam_role.ecs_tasks_role.*.arn, [""]), 0)
 }
 
 output "ecs_taskrole_name" {
   description = "ecs_taskrole_name outputs the Role-name of the ECS Task"
-  value       = "${element(concat(aws_iam_role.ecs_tasks_role.*.name, list("")), 0)}"
+  value       = element(concat(aws_iam_role.ecs_tasks_role.*.name, [""]), 0)
 }
 
 output "lambda_lookup_role_arn" {
   description = "IAM Role arn of the lambda lookup helper"
-  value       = "${element(concat(aws_iam_role.lambda_lookup.*.arn, list("")), 0)}"
+  value       = element(concat(aws_iam_role.lambda_lookup.*.arn, [""]), 0)
 }
 
 output "lambda_lookup_role_name" {
   description = "IAM Role name of the lambda lookup helper"
-  value       = "${element(concat(aws_iam_role.lambda_lookup.*.name, list("")), 0)}"
+  value       = element(concat(aws_iam_role.lambda_lookup.*.name, [""]), 0)
 }
 
 output "lambda_lookup_role_policy_id" {
   description = "policy ID of the lambda role, this to force dependency"
-  value       = "${element(concat(aws_iam_role_policy.lambda_lookup_policy.*.id, list("")), 0)}"
+  value = element(
+    concat(aws_iam_role_policy.lambda_lookup_policy.*.id, [""]),
+    0,
+  )
 }
 
 output "lambda_ecs_task_scheduler_role_arn" {
   description = "IAM Role arn of the lambda lookup helper"
-  value       = "${element(concat(aws_iam_role.lambda_ecs_task_scheduler.*.arn, list("")), 0)}"
+  value = element(
+    concat(aws_iam_role.lambda_ecs_task_scheduler.*.arn, [""]),
+    0,
+  )
 }
 
 output "scheduled_task_cloudwatch_role_arn" {
   description = "Arn for the role assumed by CloudWatch to execute scheduling events."
-  value       = "${element(concat(aws_iam_role.scheduled_task_cloudwatch.*.arn, list("")), 0)}"
+  value = element(
+    concat(aws_iam_role.scheduled_task_cloudwatch.*.arn, [""]),
+    0,
+  )
 }
+

--- a/modules/iam/variables.tf
+++ b/modules/iam/variables.tf
@@ -62,3 +62,8 @@ variable "is_scheduled_task" {
   default     = false
 }
 
+variable "tags" {
+  description = "A map of tags to apply to all taggable resources"
+  type        = map(string)
+  default     = {}
+}

--- a/modules/iam/variables.tf
+++ b/modules/iam/variables.tf
@@ -62,6 +62,11 @@ variable "is_scheduled_task" {
   default     = false
 }
 
+variable "task_scheduler_enabled" {
+  description = "Whether to create a role for the Lambda-based task scheduler"
+  default = true
+}
+
 variable "tags" {
   description = "A map of tags to apply to all taggable resources"
   type        = map(string)

--- a/modules/iam/variables.tf
+++ b/modules/iam/variables.tf
@@ -42,6 +42,11 @@ variable "ssm_paths" {
   default     = []
 }
 
+variable "secretsmanager_secret_arns" {
+  description = "ARNs of Secrets Manager secrets to allow access to"
+  default = []
+}
+
 variable "s3_ro_paths" {
   description = "S3 Read-only paths the Task has access to."
   default     = []

--- a/modules/iam/variables.tf
+++ b/modules/iam/variables.tf
@@ -10,7 +10,8 @@ variable "name" {
   default = ""
 }
 
-variable "ecs_cluster_id" {}
+variable "ecs_cluster_id" {
+}
 
 variable "fargate_enabled" {
   default = false
@@ -55,3 +56,4 @@ variable "is_scheduled_task" {
   description = "If true, this not a service, but a schedulked task."
   default     = false
 }
+

--- a/modules/iam/variables.tf
+++ b/modules/iam/variables.tf
@@ -17,11 +17,6 @@ variable "fargate_enabled" {
   default = false
 }
 
-variable "container_secrets_enabled" {
-  description = "true, if the container needs access to SSM secrets"
-  default     = false
-}
-
 variable "kms_enabled" {
   description = "Whether to provide access to the supplied kms_keys. If no kms keys are passed, set this to false."
   default     = false
@@ -40,6 +35,11 @@ variable "ssm_enabled" {
 variable "ssm_paths" {
   description = "List of SSM Paths the task has access to."
   default     = []
+}
+
+variable "secretsmanager_enabled" {
+  description = "true, if the container needs access to Secrets Manager secrets"
+  default     = false
 }
 
 variable "secretsmanager_secret_arns" {

--- a/modules/lambda_ecs_task_scheduler/variables.tf
+++ b/modules/lambda_ecs_task_scheduler/variables.tf
@@ -1,17 +1,22 @@
 # create defines if resources are created inside this module
-variable "create" {}
+variable "create" {
+}
 
 # ecs_cluster_id sets the cluster id
-variable "ecs_cluster_id" {}
+variable "ecs_cluster_id" {
+}
 
 # ecs_service_name sets the service name
-variable "ecs_service_name" {}
+variable "ecs_service_name" {
+}
 
 # Container name to run the command in
-variable "container_name" {}
+variable "container_name" {
+}
 
 # Role of the AWS Lambda
-variable "lambda_ecs_task_scheduler_role_arn" {}
+variable "lambda_ecs_task_scheduler_role_arn" {
+}
 
 # ecs_cron_tasks holds a list of maps defining the scheduled jobs which need to run
 #
@@ -29,16 +34,17 @@ variable "lambda_ecs_task_scheduler_role_arn" {}
 #
 #   },]
 variable "ecs_cron_tasks" {
-  type    = "list"
+  type    = list(map(string))
   default = []
 }
 
 # Tags applied to the resources in the submodule
 variable "tags" {
-  type    = "map"
+  type    = map(string)
   default = {}
 }
 
 variable "lambda_runtime" {
-  type = "string"
+  type = string
 }
+

--- a/modules/live_task_lookup/main.tf
+++ b/modules/live_task_lookup/main.tf
@@ -36,7 +36,7 @@ resource "aws_lambda_function" "lambda_lookup" {
 }
 
 data "aws_lambda_invocation" "lambda_lookup" {
-  count         = var.create && var.lookup_type == "lambda" ? 1 : 0
+  count         = var.create && var.lookup_type == "lambda" && length(aws_lambda_function.lambda_lookup) > 0 ? 1 : 0
   function_name = aws_lambda_function.lambda_lookup[0].function_name
   qualifier     = aws_lambda_function.lambda_lookup[0].version
 

--- a/modules/live_task_lookup/main.tf
+++ b/modules/live_task_lookup/main.tf
@@ -2,8 +2,8 @@
 # This null_resources forces a dependency
 #
 resource "null_resource" "force_policy_dependency" {
-  triggers {
-    listeners = "${var.lambda_lookup_role_policy_id}"
+  triggers = {
+    listeners = var.lambda_lookup_role_policy_id
   }
 }
 
@@ -18,27 +18,27 @@ data "archive_file" "lookup_zip" {
 # lookup_type lambda
 #
 resource "aws_lambda_function" "lambda_lookup" {
-  count            = "${var.create ? 1 : 0}"
+  count            = var.create ? 1 : 0
   function_name    = "${basename(var.ecs_cluster_id)}-${var.ecs_service_name}-lambda-lookup"
   handler          = "index.handler"
-  runtime          = "${var.lambda_runtime}"
+  runtime          = var.lambda_runtime
   filename         = "${path.module}/lookup.zip"
-  source_code_hash = "${data.archive_file.lookup_zip.output_base64sha256}"
-  role             = "${var.lambda_lookup_role_arn}"
+  source_code_hash = data.archive_file.lookup_zip.output_base64sha256
+  role             = var.lambda_lookup_role_arn
   publish          = true
-  tags             = "${var.tags}"
+  tags             = var.tags
 
   lifecycle {
-    ignore_changes = ["*"]
+    ignore_changes = all
   }
 
-  depends_on = ["null_resource.force_policy_dependency"]
+  depends_on = [null_resource.force_policy_dependency]
 }
 
 data "aws_lambda_invocation" "lambda_lookup" {
-  count         = "${var.create && var.lookup_type == "lambda" ? 1 :0 }"
-  function_name = "${aws_lambda_function.lambda_lookup.function_name}"
-  qualifier     = "${aws_lambda_function.lambda_lookup.version}"
+  count         = var.create && var.lookup_type == "lambda" ? 1 : 0
+  function_name = aws_lambda_function.lambda_lookup[0].function_name
+  qualifier     = aws_lambda_function.lambda_lookup[0].version
 
   input = <<JSON
 {
@@ -47,24 +47,26 @@ data "aws_lambda_invocation" "lambda_lookup" {
   "ecs_task_container_name": "${var.container_name}"
 }
 JSON
+
 }
 
 #
 # lookup_type datasource
 #
 data "aws_ecs_service" "lookup" {
-  count        = "${var.create && var.lookup_type == "datasource" ? 1 : 0 }"
-  service_name = "${var.ecs_service_name}"
-  cluster_arn  = "${var.ecs_cluster_id}"
+  count        = var.create && var.lookup_type == "datasource" ? 1 : 0
+  service_name = var.ecs_service_name
+  cluster_arn  = var.ecs_cluster_id
 }
 
 data "aws_ecs_task_definition" "lookup" {
-  count           = "${var.create && var.lookup_type == "datasource" ? 1 : 0 }"
-  task_definition = "${data.aws_ecs_service.lookup.task_definition}"
+  count           = var.create && var.lookup_type == "datasource" ? 1 : 0
+  task_definition = data.aws_ecs_service.lookup[0].task_definition
 }
 
 data "aws_ecs_container_definition" "lookup" {
-  count           = "${var.create && var.lookup_type == "datasource" ? 1 : 0 }"
-  task_definition = "${data.aws_ecs_service.lookup.task_definition}"
-  container_name  = "${var.container_name}"
+  count           = var.create && var.lookup_type == "datasource" ? 1 : 0
+  task_definition = data.aws_ecs_service.lookup[0].task_definition
+  container_name  = var.container_name
 }
+

--- a/modules/live_task_lookup/output.tf
+++ b/modules/live_task_lookup/output.tf
@@ -10,69 +10,79 @@ locals {
   }
 
   # Lambda invoke returns a map, but as it's inside a conditional coalescelist make sure it can be looked up when it does not exist
-  safe_lambda_lookup = "${coalescelist(data.aws_lambda_invocation.lambda_lookup.*.result_map, list(local.empty_lookup))}"
+  safe_lambda_lookup = coalescelist(
+    data.aws_lambda_invocation.lambda_lookup.*.result_map,
+    [local.empty_lookup],
+  )
 
   # First item of the list is the actual map
-  lambda_lookup = "${local.safe_lambda_lookup[0]}"
+  lambda_lookup = local.safe_lambda_lookup[0]
 
   # data.aws_ecs_container_definition.lookup returns a map, coalescelist again makes it save to use inside a conditional
-  environment_coalesce = "${coalescelist(data.aws_ecs_container_definition.lookup.*.environment, list(map()))}"
+  environment_coalesce = coalescelist(data.aws_ecs_container_definition.lookup.*.environment, [{}])
 
-  dockerlabels_coalesce = "${coalescelist(data.aws_ecs_container_definition.lookup.*.docker_labels, list(map("_airship_dockerlabel_hash","","_airship_secrets_hash","")))}"
+  dockerlabels_coalesce = coalescelist(
+    data.aws_ecs_container_definition.lookup.*.docker_labels,
+    [
+      {
+        "_airship_dockerlabel_hash" = ""
+        "_airship_secrets_hash"     = ""
+      },
+    ],
+  )
 }
 
 output "docker_label_hash" {
-  value = "${var.lookup_type == "lambda" ? 
-              lookup(local.lambda_lookup, "docker_label_hash", "") :
-                ( var.lookup_type == "datasource" ?
-                   lookup(local.dockerlabels_coalesce[0],"_airship_dockerlabel_hash", "") : "" )}"
+  value = var.lookup_type == "lambda" ? lookup(local.lambda_lookup, "docker_label_hash", "") : var.lookup_type == "datasource" ? lookup(
+    local.dockerlabels_coalesce[0],
+    "_airship_dockerlabel_hash",
+    "",
+  ) : ""
 }
 
 output "secrets_hash" {
-  value = "${var.lookup_type == "lambda" ? 
-              lookup(local.lambda_lookup, "secrets_hash", "") :
-                ( var.lookup_type == "datasource" ?
-                   lookup(local.dockerlabels_coalesce[0],"_airship_secrets_hash", "") : "" )}"
+  value = var.lookup_type == "lambda" ? lookup(local.lambda_lookup, "secrets_hash", "") : var.lookup_type == "datasource" ? lookup(local.dockerlabels_coalesce[0], "_airship_secrets_hash", "") : ""
 }
 
 output "environment_json" {
-  value = "${var.lookup_type == "lambda" ? 
-              lookup(local.lambda_lookup, "environment", "") :
-                ( var.lookup_type == "datasource" ?
-                   jsonencode(local.environment_coalesce[0]) : "" )}"
+  value = var.lookup_type == "lambda" ? lookup(local.lambda_lookup, "environment", "") : var.lookup_type == "datasource" ? jsonencode(local.environment_coalesce[0]) : ""
 }
 
 output "image" {
-  value = "${var.lookup_type == "lambda" ? 
-                lookup(local.lambda_lookup, "image", "") : 
-                  ( var.lookup_type == "datasource" ? 
-                     element(concat(data.aws_ecs_container_definition.lookup.*.image, list("")), 0) : "" )}"
+  value = var.lookup_type == "lambda" ? lookup(local.lambda_lookup, "image", "") : var.lookup_type == "datasource" ? element(
+    concat(data.aws_ecs_container_definition.lookup.*.image, [""]),
+    0,
+  ) : ""
 }
 
 output "cpu" {
-  value = "${var.lookup_type == "lambda" ? 
-              lookup(local.lambda_lookup, "cpu", "") : 
-                ( var.lookup_type == "datasource" ? 
-                   element(concat(data.aws_ecs_container_definition.lookup.*.cpu, list("")), 0) : "" )}"
+  value = var.lookup_type == "lambda" ? lookup(local.lambda_lookup, "cpu", "") : var.lookup_type == "datasource" ? element(
+    concat(data.aws_ecs_container_definition.lookup.*.cpu, [""]),
+    0,
+  ) : ""
 }
 
 output "memory" {
-  value = "${var.lookup_type == "lambda" ? 
-              lookup(local.lambda_lookup, "memory", "") : 
-                ( var.lookup_type == "datasource" ? 
-                   element(concat(data.aws_ecs_container_definition.lookup.*.memory, list("")), 0) : "" )}"
+  value = var.lookup_type == "lambda" ? lookup(local.lambda_lookup, "memory", "") : var.lookup_type == "datasource" ? element(
+    concat(data.aws_ecs_container_definition.lookup.*.memory, [""]),
+    0,
+  ) : ""
 }
 
 output "memory_reservation" {
-  value = "${var.lookup_type == "lambda" ? 
-              lookup(local.lambda_lookup, "memory_reservation", "") : 
-                ( var.lookup_type == "datasource" ? 
-                   element(concat(data.aws_ecs_container_definition.lookup.*.memory_reservation, list("")), 0) : "" )}"
+  value = var.lookup_type == "lambda" ? lookup(local.lambda_lookup, "memory_reservation", "") : var.lookup_type == "datasource" ? element(
+    concat(
+      data.aws_ecs_container_definition.lookup.*.memory_reservation,
+      [""],
+    ),
+    0,
+  ) : ""
 }
 
 output "revision" {
-  value = "${var.lookup_type == "lambda" ? 
-              lookup(local.lambda_lookup, "task_revision", "") : 
-                ( var.lookup_type == "datasource" ? 
-                   element(concat(data.aws_ecs_task_definition.lookup.*.revision, list("")), 0) : "" )}"
+  value = var.lookup_type == "lambda" ? lookup(local.lambda_lookup, "task_revision", "") : var.lookup_type == "datasource" ? element(
+    concat(data.aws_ecs_task_definition.lookup.*.revision, [""]),
+    0,
+  ) : ""
 }
+

--- a/modules/live_task_lookup/output.tf
+++ b/modules/live_task_lookup/output.tf
@@ -9,14 +9,11 @@ locals {
     docker_label_hash  = ""
   }
 
-  # Lambda invoke returns a map, but as it's inside a conditional coalescelist make sure it can be looked up when it does not exist
-  safe_lambda_lookup = coalescelist(
-    data.aws_lambda_invocation.lambda_lookup.*.result_map,
-    [local.empty_lookup],
+  # Lambda invoke returns a map, but as it's inside a conditional try make sure it can be looked up when it does not exist
+  lambda_lookup = try(
+    jsondecode(data.aws_lambda_invocation.lambda_lookup[0].result),
+    local.empty_lookup,
   )
-
-  # First item of the list is the actual map
-  lambda_lookup = local.safe_lambda_lookup[0]
 
   # data.aws_ecs_container_definition.lookup returns a map, coalescelist again makes it save to use inside a conditional
   environment_coalesce = coalescelist(data.aws_ecs_container_definition.lookup.*.environment, [{}])

--- a/modules/live_task_lookup/variables.tf
+++ b/modules/live_task_lookup/variables.tf
@@ -1,20 +1,26 @@
 # ecs_service_name sets the service name
-variable "ecs_service_name" {}
+variable "ecs_service_name" {
+}
 
 # create sets if resources are created
-variable "create" {}
+variable "create" {
+}
 
 # container_name sets the name of the container where we lookup the container_image
-variable "container_name" {}
+variable "container_name" {
+}
 
 # ecs_cluster_id sets the cluster id
-variable "ecs_cluster_id" {}
+variable "ecs_cluster_id" {
+}
 
 # lambda_lookup_role_arn sets the role arn of the lookup_lambda
-variable "lambda_lookup_role_arn" {}
+variable "lambda_lookup_role_arn" {
+}
 
 # lambda_lookup_role_policy_id sets the id of the added policy to the lambda, this to force dependency
-variable "lambda_lookup_role_policy_id" {}
+variable "lambda_lookup_role_policy_id" {
+}
 
 # lookup_type sets the type of lookup, either
 # * lambda - works during bootstrap and after bootstrap
@@ -33,7 +39,7 @@ variable "allowed_lookup_types" {
 
 locals {
   # validating the var.lookup_type input
-  test_lookup_type = "${lookup(var.allowed_lookup_types, var.lookup_type)}"
+  test_lookup_type = var.allowed_lookup_types[var.lookup_type]
 }
 
 # tags
@@ -42,5 +48,6 @@ variable "tags" {
 }
 
 variable "lambda_runtime" {
-  type = "string"
+  type = string
 }
+

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,31 +1,32 @@
 output "ecs_taskrole_arn" {
-  value = "${module.iam.ecs_taskrole_arn}"
+  value = module.iam.ecs_taskrole_arn
 }
 
 output "ecs_taskrole_name" {
-  value = "${module.iam.ecs_taskrole_name}"
+  value = module.iam.ecs_taskrole_name
 }
 
 output "lb_target_group_arn" {
-  value = "${module.alb_handling.lb_target_group_arn}"
+  value = module.alb_handling.lb_target_group_arn
 }
 
 output "task_execution_role_arn" {
-  value = "${module.iam.ecs_task_execution_role_arn}"
+  value = module.iam.ecs_task_execution_role_arn
 }
 
 output "task_execution_role_name" {
-  value = "${module.iam.ecs_task_execution_role_name}"
+  value = module.iam.ecs_task_execution_role_name
 }
 
 output "aws_ecs_task_definition_arn" {
-  value = "${module.ecs_task_definition_selector.selected_task_definition_for_deployment}"
+  value = module.ecs_task_definition_selector.selected_task_definition_for_deployment
 }
 
 output "aws_ecs_task_definition_family" {
-  value = "${module.ecs_task_definition.aws_ecs_task_definition_family}"
+  value = module.ecs_task_definition.aws_ecs_task_definition_family
 }
 
 output "has_changed" {
-  value = "${module.ecs_task_definition_selector.has_changed}"
+  value = module.ecs_task_definition_selector.has_changed
 }
+

--- a/variables.tf
+++ b/variables.tf
@@ -2,83 +2,98 @@
 # of the map is being defined. This is mitigated by using an extra set of default_* variables 
 
 variable "create" {
+  type        = bool
   default     = true
   description = "create is the variable used in all resources to conditionally create them"
 }
 
 variable "ecs_cluster_id" {
+  type        = string
   description = "The cluster to which the ECS Service will be added"
 }
 
 variable "region" {
+  type        = string
   description = "Region of the ECS Cluster"
 }
 
 variable "fargate_enabled" {
+  type        = bool
   description = "With fargate_enabled the launchtype of the service will be FARGATE, otherwise EC2 ( default is false)"
   default     = false
 }
 
 variable "container_secrets_enabled" {
+  type        = bool
   description = "true, if the container uses secrets and needs a task execution role to get access to them"
   default     = false
 }
 
 variable "container_init_process_enabled" {
+  type        = bool
   description = "Should the container be run with initProcessEnabled (--init)"
   default     = false
 }
 
 variable "awsvpc_enabled" {
+  type        = bool
   default     = false
   description = "With awsvpc_enabled the network_mode for the ECS task definition will be awsvpc, defaults to bridge"
 }
 
 variable "log_retention_in_days" {
-  default     = "14"
+  type        = number
+  default     = 14
   description = "Number of days for the cloudwatch logs for the containers to be retained"
 }
 
 variable "cloudwatch_kms_key" {
+  type        = string
   default     = ""
   description = "kms_key for the cloudwatch logs"
 }
 
 variable "scheduling_strategy" {
+  type        = string
   default     = "REPLICA"
   description = "scheduling_strategy defaults to REPLICA"
 }
 
 variable "with_placement_strategy" {
+  type        = bool
   default     = false
   description = "Spread tasks over ECS Cluster based on AZ, Instance-id, memory"
 }
 
 variable "deployment_controller_type" {
+  type        = string
   description = <<EOF
 deployment_controller_type sets the deployment type
 ECS for Rolling update, and CODE_DEPLOY for Blue/Green deployment via CodeDeploy
 EOF
-
-  default = "ECS"
+  default     = "ECS"
 }
 
 variable "load_balancing_properties_lb_arn" {
+  type        = string
   description = "The arn of the ALB or NLB being used"
   default     = ""
 }
 
 variable "load_balancing_type" {
+  type        = string
   default     = "none"
   description = "load_balancing_type is either \"none\", \"network\",\"application\""
 }
 
 variable "load_balancing_properties_route53_record_type" {
+  type        = string
   description = "By default we create an ALIAS to the ALB, this can be set to CNAME, or NONE to not create any records"
   default     = "ALIAS"
 }
 
 variable "load_balancing_properties_route53_custom_name" {
+  type        = string
   description = "By default we create a subdomain with using var.name, override with load_balancing_properties_route53_custom_name"
   default     = ""
 }
@@ -86,112 +101,133 @@ variable "load_balancing_properties_route53_custom_name" {
 variable "load_balancing_properties_custom_listen_hosts" {
   description = "Extra hosts the ALB needs to make listener_rules for to the ECS target group"
   default     = []
-  type        = "list"
+  type        = list(string)
 }
 
 variable "load_balancing_properties_custom_listen_hosts_count" {
+  type        = number
   description = "necessary count for the load_balancing_properties_custom_listen_hosts"
   default     = 0
 }
 
 variable "load_balancing_properties_redirect_http_to_https" {
+  type        = bool
   description = "Redirect http to https instead of serving http"
   default     = false
 }
 
 variable "load_balancing_properties_lb_listener_arn" {
+  type        = string
   description = "lb_listener_arn is the ALB listener arn for HTTP"
   default     = ""
 }
 
 variable "load_balancing_properties_lb_listener_arn_https" {
+  type        = string
   description = "lb_listener_arn_https is the ALB listener arn for HTTPS"
   default     = ""
 }
 
 variable "load_balancing_properties_nlb_listener_port" {
+  type        = string
   description = "nlb_listener_port is the default port for the Network Load Balancer to listen on"
   default     = "80"
 }
 
 variable "load_balancing_properties_target_group_port" {
+  type        = string
   description = "target_group_port sets the port for the alb or nlb target group, this generally can stay 80 regardless of the service port"
   default     = "80"
 }
 
 variable "load_balancing_properties_lb_vpc_id" {
+  type        = string
   description = "lb_vpc_id is the vpc_id for the target_group to reside in"
   default     = ""
 }
 
 variable "load_balancing_properties_route53_zone_id" {
+  type        = string
   description = "route53_zone_id is the zone to add a subdomain to"
   default     = ""
 }
 
 variable "load_balancing_properties_health_uri" {
+  type        = string
   description = "health_uri is the health uri to be checked by the ALB"
   default     = "/ping"
 }
 
 variable "load_balancing_properties_health_matcher" {
+  type        = string
   description = "health_matcher sets the expected HTTP status for the health check to be marked healthy"
   default     = "200"
 }
 
 variable "load_balancing_properties_health_port" {
+  type        = string
   description = "health_port is the port of health uri to be checked by the ALB"
   default     = "traffic-port"
 }
 
 variable "load_balancing_properties_unhealthy_threshold" {
+  type        = number
   description = "The number of consecutive successful health checks required before considering an healthy target unhealthy"
-  default     = "3"
+  default     = 3
 }
 
 variable "load_balancing_properties_healthy_threshold" {
+  type        = number
   description = "The number of consecutive successful health checks required before considering an unhealthy target healthy"
-  default     = "3"
+  default     = 3
 }
 
 variable "load_balancing_properties_https_enabled" {
+  type        = bool
   description = "load_balancing_properties_https_enabled enables listener rules creation for https"
   default     = true
 }
 
 variable "load_balancing_properties_deregistration_delay" {
+  type        = number
   description = "load_balancing_properties_deregistration_delay sets the deregistration_delay for the targetgroup"
   default     = 300
 }
 
 variable "load_balancing_properties_route53_record_identifier" {
+  type        = string
   description = "route53_record_identifier sets the A ALIAS record identifier"
   default     = "identifier"
 }
 
 variable "load_balancing_properties_cognito_auth_enabled" {
+  type        = bool
   description = "Set to true when cognito authentication is used for the https listener"
   default     = false
 }
 
 variable "load_balancing_properties_cognito_user_pool_arn" {
+  type        = string
   description = "load_balancing_properties_cognito_user_pool_arn defines the cognito user pool arn for the added cognito authentication"
   default     = ""
 }
 
 variable "load_balancing_properties_cognito_user_pool_client_id" {
+  type        = string
   description = "load_balancing_properties_cognito_user_pool_client_id defines the cognito_user_pool_client_id"
   default     = ""
 }
 
 variable "load_balancing_properties_cognito_user_pool_domain" {
+  type        = string
   description = "load_balancing_properties_cognito_user_pool_domain defines the cognito_user_pool_domain"
   default     = ""
 }
 
 variable "capacity_properties_desired_capacity" {
+  type        = number
   description = "capacity_properties_desired_capacity is the desired amount of tasks for a service, when autoscaling is used desired_capacity is only used initially"
-  default     = "2"
+  default     = 2
 }
 
 variable "capacity_properties_desired_min_capacity" {
@@ -226,12 +262,13 @@ When the type is set to `datasource` regular terraform datasources are used to l
 Downside of datasource is that it cannot be used for bootstrapping.
 EOF
 
+
   default = "lambda"
 }
 
 variable "live_task_lookup_lambda_runtime" {
   description = "Runtime version of live task lookup lambda"
-  type        = "string"
+  type        = string
   default     = "nodejs12.x"
 }
 
@@ -267,13 +304,13 @@ variable "container_port" {
 }
 
 variable "container_healthcheck" {
-  type        = "map"
+  type        = map(string)
   default     = {}
   description = "healthcheck, describes the extra HEALTHCHECK for the container"
 }
 
 variable "container_command" {
-  type        = "list"
+  type        = list(string)
   default     = [""]
   description = "container_command, describes the command for the container a a list, leaving default should run docker defined CMD"
 }
@@ -316,7 +353,9 @@ Scaling properties holds a map of multiple maps defining scaling policies and al
     # scaling_adjustment defines the amount to scale, can be a postive or negative number or percentage
     scaling_adjustment = "1"
   },]
-  EOF
+  
+EOF
+
 
   default = []
 }
@@ -325,7 +364,9 @@ variable "container_envvars" {
   description = <<EOF
 container_envvars defines extra container env vars, list of maps:
 { key = val,key2= val2}
-  EOF
+  
+EOF
+
 
   default = {}
 }
@@ -337,13 +378,14 @@ Example:
 ```hcl
 container_secrets_enabled = true
 container_secrets = {
-  DB_USER     = "${data.aws_ssm_parameter.username.arn}"
+  DB_USER     = "$${data.aws_ssm_parameter.username.arn}"
   DB_PASSWORD = "/myapp/dev/db.password"
 }
 ssm_enabled = true
 ssm_paths   = ["myapp/dev"]
 ```
 EOF
+
 
   default = {}
 }
@@ -393,10 +435,9 @@ variable "s3_rw_paths" {
 }
 
 variable "docker_volume" {
-  type        = "map"
+  type        = map(string)
   default     = {}
   description = "A Docker volume to add to the task"
-
   # {
   # # these properties are supported as a 'flattened' version of the docker volume configuration:
   # # https://www.terraform.io/docs/providers/aws/r/ecs_task_definition.html#docker_volume_configuration
@@ -411,10 +452,9 @@ variable "docker_volume" {
 }
 
 variable "host_path_volumes" {
-  type        = "list"
+  type        = list(map(string))
   default     = []
   description = "list of host paths to add as volumes to the task"
-
   ## Example:
   # host_path_volumes = [{
   #   name = "foo",
@@ -427,10 +467,9 @@ variable "host_path_volumes" {
 }
 
 variable "mountpoints" {
-  type        = "list"
+  type        = list(map(string))
   default     = []
   description = "list of mount points to add to every container in the task"
-
   ## Example 
   # mountpoints = [{
   #   sourceVolume = "foo",
@@ -460,11 +499,11 @@ ecs_cron_tasks holds a list of maps defining the scheduled jobs which need to ru
     command = "python vacuum_db.py"
 
   },]
-  EOF
+  
+EOF
 
-  type    = "list"
+  type    = list(map(string))
   default = []
-
   ## ecs_cron_tasks holds a list of maps defining the scheduled jobs which need to run
   ## Example
 
@@ -514,7 +553,7 @@ variable "service_discovery_properties_healthcheck_custom_failure_threshold" {
 
 variable "tags" {
   description = "A map of tags to apply to all taggable resources"
-  type        = "map"
+  type        = map(string)
   default     = {}
 }
 
@@ -525,24 +564,24 @@ variable "health_check_grace_period_seconds" {
 
 variable "repository_credentials_secret_arn" {
   description = "ARN of Docker private registry credentials stored in secrets manager"
-  type        = "string"
+  type        = string
   default     = ""
 }
 
 variable "container_ulimit_name" {
-  type        = "string"
+  type        = string
   default     = "nofile"
   description = "ECS container definition ulimits name"
 }
 
 variable "container_ulimit_soft_limit" {
-  type        = "string"
+  type        = string
   default     = ""
   description = "ECS container definition ulimits soft limit"
 }
 
 variable "container_ulimit_hard_limit" {
-  type        = "string"
+  type        = string
   default     = ""
   description = "ECS containter definition ulimits hard limit"
 }
@@ -552,6 +591,7 @@ variable "is_scheduled_task" {
 When this is enabled, any load balancer- and autoscaling settings are ignored, and no ECS service is created. 
 Instead, a scheduled task is created using the task defintion and the 'scheduled_task_*' settings.
 EOF
+
 
   default = false
 }
@@ -578,6 +618,7 @@ variable "scheduled_task_name" {
 
 variable "lambda_ecs_task_scheduler_runtime" {
   description = "Runtime version of ecs task scheduler lambda"
-  type        = "string"
+  type        = string
   default     = "nodejs12.x"
 }
+

--- a/variables.tf
+++ b/variables.tf
@@ -317,7 +317,7 @@ variable "container_healthcheck" {
 
 variable "container_command" {
   type        = list(string)
-  default     = [""]
+  default     = []
   description = "container_command, describes the command for the container a a list, leaving default should run docker defined CMD"
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -337,6 +337,11 @@ variable "host_port" {
   description = "host_port, to be filled in to have a static host port mapping for non-awsvpc ecs, defaults to dynamic port mapping"
 }
 
+variable "extra_ports" {
+  description = "Port mappings to apply besides the default"
+  default = []
+}
+
 variable "scaling_properties" {
   description = <<EOF
 Scaling properties holds a map of multiple maps defining scaling policies and alarms

--- a/variables.tf
+++ b/variables.tf
@@ -41,6 +41,12 @@ variable "awsvpc_enabled" {
   description = "With awsvpc_enabled the network_mode for the ECS task definition will be awsvpc, defaults to bridge"
 }
 
+variable "assign_public_ip" {
+  type        = bool
+  default     = false
+  description = "Should a service with awsvpc networking be assigned a public IP address"
+}
+
 variable "log_retention_in_days" {
   type        = number
   default     = 14

--- a/variables.tf
+++ b/variables.tf
@@ -309,10 +309,15 @@ variable "container_port" {
   description = "port defines the needed port of the container"
 }
 
-variable "container_healthcheck" {
-  type        = map(string)
+variable "container_healthcheck_cmd" {
+  description = "healthcheck command, either a string or array of strings"
+  default     = null
+}
+
+variable "container_healthcheck_timings" {
+  type        = map(number)
   default     = {}
-  description = "healthcheck, describes the extra HEALTHCHECK for the container"
+  description = "healthcheck timing parameters: interval, retries, startPeriod, timeout"
 }
 
 variable "container_command" {
@@ -553,7 +558,8 @@ variable "service_discovery_properties_routing_policy" {
 }
 
 variable "service_discovery_properties_healthcheck_custom_failure_threshold" {
-  default     = "1"
+  type        = number
+  default     = 1
   description = "The number of 30-second intervals that you want service discovery to wait before it changes the health status of a service instance. Maximum value of 10."
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -379,7 +379,7 @@ EOF
 
 variable "container_secrets" {
   description = <<EOF
-The environment variables to pass to the container as SSM keys.  Should be a map of environment vairable names to either SSM var ANRs or paths.
+The environment variables to pass to the container as SSM keys or Secrets Manager ARNs.  Should be a map of environment vairable names to SSM var ARNs or paths, or Secrets Manager ARNs.
 Example:
 ```hcl
 container_secrets_enabled = true
@@ -571,7 +571,7 @@ variable "health_check_grace_period_seconds" {
 variable "repository_credentials_secret_arn" {
   description = "ARN of Docker private registry credentials stored in secrets manager"
   type        = string
-  default     = ""
+  default     = null
 }
 
 variable "container_ulimit_name" {

--- a/variables.tf
+++ b/variables.tf
@@ -188,6 +188,12 @@ variable "load_balancing_properties_healthy_threshold" {
   default     = 3
 }
 
+variable "load_balancing_properties_http_enabled" {
+  type        = bool
+  description = "load_balancing_properties_http_enabled enables listener rules creation for http"
+  default     = true
+}
+
 variable "load_balancing_properties_https_enabled" {
   type        = bool
   description = "load_balancing_properties_https_enabled enables listener rules creation for https"


### PR DESCRIPTION
This gets most functionality working on Terraform 0.12.

It also makes some functional changes:
* Add `assign_public_ip` option
* Allow specifying repository credentials
* Separate out health check parameters as `healthcheck_cmd`, `healthcheck_timings`
* Apply tags to everything
* Add Secrets Manager support
* Add `http_enabled` variable so HTTP can be disabled entirely
* Only create task scheduler role when needed
* Allow exposing extra container ports